### PR TITLE
Minor bugfix with RDKitMol.SetAtomMapNumbers()

### DIFF
--- a/rdmc/mol.py
+++ b/rdmc/mol.py
@@ -753,7 +753,7 @@ class RDKitMol(object):
             atomMap(list, tuple, optional): A sequence of integers for atom mapping.
         """
         num_atoms = self.GetNumAtoms()
-        if atomMap:
+        if atomMap is not None:
             if len(atomMap) != num_atoms:
                 raise ValueError('Invalid atomMap provided. It should have the same length as atom numbers.')
         else:


### PR DESCRIPTION
This PR fixes a minor bug with `RDKitMol.SetAtomMapNumbers()`. The syntax of `if <iteratable>:` gives the error

```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
This PR implements the simple fix. 

Thanks for this great wrapper!!!