### PR TITLE
Deal with carbene & avoid `UnboundLocalError`

### DIFF
--- a/rdmc/external/rmg.py
+++ b/rdmc/external/rmg.py
@@ -50,12 +50,15 @@ def load_rmg_database(families: list = [],
 def from_rdkit_mol(rdkitmol,
                    sort: bool = False,
                    raise_atomtype_exception: bool = True,
+                   smiles: str = None,
                    ) -> 'Molecule':
     """
     Convert a RDKit Mol object `rdkitmol` to a molecular structure. Uses
     `RDKit <http://rdkit.org/>`_ to perform the conversion.
     This Kekulizes everything, removing all aromatic atom types.
     """
+    is_carbene_or_nitrene = False
+
     mol = mm.Molecule()
     mol.vertices = []
 
@@ -78,7 +81,14 @@ def from_rdkit_mol(rdkitmol,
         charge = rdkitatom.GetFormalCharge()
         radical_electrons = rdkitatom.GetNumRadicalElectrons()
 
-        atom = mm.Atom(element, radical_electrons, charge, '', 0)
+        if (radical_electrons == 2 and element.symbol == "C") or smiles == "[CH2]":
+            is_carbene_or_nitrene = True
+            atom = mm.Atom(element, 0, charge, '', 1)
+        elif (radical_electrons == 2 and element.symbol == "N") or smiles == "[NH]":
+            is_carbene_or_nitrene = True
+            atom = mm.Atom(element, 0, charge, '', 1)
+        else:
+            atom = mm.Atom(element, radical_electrons, charge, '', 0)
         mol.vertices.append(atom)
 
         # Add bonds by iterating again through atoms
@@ -112,7 +122,11 @@ def from_rdkit_mol(rdkitmol,
     # Assume this is always true
     # There are cases where 2 radical_electrons is a singlet, but
     # the triplet is often more stable,
-    mol.multiplicity = mol.get_radical_count() + 1
+
+    if is_carbene_or_nitrene:
+        mol.multiplicity = 1
+    else:
+        mol.multiplicity = mol.get_radical_count() + 1
     # mol.update_atomtypes()
 
     return mol

--- a/rdmc/mol.py
+++ b/rdmc/mol.py
@@ -803,8 +803,7 @@ class RDKitMol(object):
                     self.EmbedConformer()
                 except RuntimeError:
                     self.EmbedNullConformer()
-                else:
-                    conf = self.GetConformer()
+                conf = self.GetConformer()
             else:
                 raise
         conf.SetPositions(coords)


### PR DESCRIPTION
I added code to deal with carbene and nitrene, and I move the `conf = self.GetConformer()` outside of the else block, since the else block is only performed for the code in the try block, but not the except block.