### PR TITLE
Vdw matrix

### DIFF
--- a/rdmc/mol.py
+++ b/rdmc/mol.py
@@ -949,6 +949,18 @@ class RDKitMol(object):
         """
         return Chem.GetFormalCharge(self._mol)
 
+    def GetInternalCoordinates(self,
+                               nonredundant: bool = True,
+                               ) -> list:
+        """
+        Get internal coordinates of the molecule.
+        """
+        bonds, angles, torsions = get_internal_coords(self.ToOBMol(),
+                                                      nonredundant=nonredundant)
+        return [[[element - 1 for element in item]
+                  for item in ic]
+                  for ic in [bonds, angles, torsions]]
+
     def GetSpinMultiplicity(self):
         """
         Get spin multiplicity of a molecule. The spin multiplicity is calculated
@@ -1255,17 +1267,6 @@ class RDKitMol(object):
         """
         self._vdw_mat = generate_vdw_mat(self, threshold, vdw_radii)
 
-    def GetInternalCoordinates(self,
-                               nonredundant: bool = True,
-                               ) -> list:
-        """
-        Get internal coordinates of the molecule.
-        """
-        bonds, angles, torsions = get_internal_coords(self.ToOBMol(),
-                                                      nonredundant=nonredundant)
-        return [[[element - 1 for element in item]
-                  for item in ic]
-                  for ic in [bonds, angles, torsions]]
 
 
 class RDKitTS(RDKitMol):

--- a/rdmc/utils.py
+++ b/rdmc/utils.py
@@ -40,6 +40,7 @@ CO_OPENBABEL_PATTERN.Init('[C;v2]=[O]')
 CARBENE_PATTERN = Chem.MolFromSmarts('[Cv0,Cv1,Cv2,Nv0,Nv1,Ov0]')
 
 PERIODIC_TABLE = Chem.GetPeriodicTable()
+VDW_RADII = {i: PERIODIC_TABLE.GetRvdw(i) for i in range(1, 36)}
 
 
 def determine_smallest_atom_index_in_torsion(atom1: 'rdkit.Chem.rdchem.Atom',


### PR DESCRIPTION
This PR adds methods to the RDKitMol and RDKitConf classes for calculating a Van der Waals matrix, which can be used to determine if the molecule has colliding atoms. This is useful as a prescreening step when generating multiple conformers, such as in ACS.

Let me know if I should change anything! Also no rush to review :)