### PR TITLE
Fix bug in HasCollidingAtoms()

### DIFF
--- a/rdmc/conf.py
+++ b/rdmc/conf.py
@@ -208,7 +208,7 @@ class RDKitConf(object):
     def HasCollidingAtoms(self) -> np.ndarray:
         dist_mat = np.triu(self.GetDistanceMatrix())
         # if the distance is smaller than a threshold, the atom has a high chance of colliding
-        return not not np.all(self.GetVdwMatrix() <= dist_mat)
+        return not np.all(self.GetVdwMatrix() <= dist_mat)
 
     def HasOwningMol(self):
         """

--- a/rdmc/mol.py
+++ b/rdmc/mol.py
@@ -745,7 +745,7 @@ class RDKitMol(object):
     def HasCollidingAtoms(self) -> np.ndarray:
         dist_mat = np.triu(self.GetDistanceMatrix())
         # if the distance is smaller than a threshold, the atom has a high chance of colliding
-        return not not np.all(self.GetVdwMatrix() <= dist_mat)
+        return not np.all(self.GetVdwMatrix() <= dist_mat)
 
     def PrepareOutputMol(self,
                           removeHs: bool = False,


### PR DESCRIPTION
This PR fixes a small but important bug from my previous PR (#9) which accidentally had double negatives. This caused the the method `HasCollidingAtoms()` to return True when it should have returned False. Sorry for not catching this the first time.