### PR TITLE
Add the option to generate resonance when searching for family

### DIFF
--- a/rdmc/external/rmg.py
+++ b/rdmc/external/rmg.py
@@ -151,8 +151,8 @@ def find_reaction_family(database: 'RMGDatabase',
         family.save_order = False
 
     if resonance:
-        reactants = [Species().from_smiles(mol.smiles) for mol in reactants]
-        products = [Species().from_smiles(mol.smiles) for mol in products]
+        reactants = [Species(molecule=[mol.copy()]) for mol in reactants]
+        products = [Species(molecule=[mol.copy()]) for mol in products]
     else:
         reactants = [mol.copy() for mol in reactants]
         products = [mol.copy() for mol in products]


### PR DESCRIPTION
Currently, reactions with resonance would return `None, None` in the function `generate_reaction_complex` if the input reactants or products are not the exact resonance structure in the reaction, even if the `resonance` option is set to `True`. This is caused by `find_reaction_family`, where no resonance is considered when generating `family_label`.

This PR passes the `resonance` option from `generate_reaction_complex` to `find_reaction_family` to enable the generation of `family_label` with resonance.