### PR TITLE
Catch error associated with save order

### DIFF
--- a/rdmc/external/rmg.py
+++ b/rdmc/external/rmg.py
@@ -252,9 +252,15 @@ def generate_reaction_complex(database: 'RMGDatabase',
 
     # Resonance structure is generated for both reactants and product
     if resonance:
-        r_to_gen = [r.copy(deep=True).generate_resonance_structures(keep_isomorphic=False,
-                                                                    filter_structures=True,
-                                                                    save_order=True) for r in reactants]
+        r_to_gen = []
+        for r in reactants:
+            try:
+                resonanced_r = r.copy(deep=True).generate_resonance_structures(keep_isomorphic=False,
+                                                                        filter_structures=True,
+                                                                        save_order=True)
+                r_to_gen.append(resonanced_r)
+            except:
+                r_to_gen.append([r])
         rs_to_gen = list(set_product(*r_to_gen))
         p_to_match = [p.copy(deep=True).generate_resonance_structures() for p in products]
         ps_to_match = list(set_product(*p_to_match))


### PR DESCRIPTION
Some nitrogen-containing species can encounter `ValueError: Number of vertices has changed cannot restore original vertex order` error while generating resonance structure and preserving the atom error due to change of vertices. However, (1) these resonance structures can be temporary, meaning that they are filtered later in the resonance code, and (2) the failure of some resonance structure shouldn't hinder the generation of reaction complex of other resonance structures.