### PR TITLE
Handle errors with C#N

### DIFF
--- a/rdmc/conformer_generation/ts_verifiers.py
+++ b/rdmc/conformer_generation/ts_verifiers.py
@@ -465,6 +465,10 @@ class TSScreener(TSVerifier):
                 mol_data.append(data)
                 ids.append(idx)
 
+        # return if nothing to screen
+        if len(mol_data) == 0:
+            return
+
         # create data batch and run screener model
         batch_data = Batch.from_data_list(mol_data)
         preds = self.module.model(batch_data) > self.threshold

--- a/rdmc/conformer_generation/ts_verifiers.py
+++ b/rdmc/conformer_generation/ts_verifiers.py
@@ -465,10 +465,6 @@ class TSScreener(TSVerifier):
                 mol_data.append(data)
                 ids.append(idx)
 
-        # return if nothing to screen
-        if len(mol_data) == 0:
-            return
-
         # create data batch and run screener model
         batch_data = Batch.from_data_list(mol_data)
         preds = self.module.model(batch_data) > self.threshold

--- a/rdmc/utils.py
+++ b/rdmc/utils.py
@@ -168,6 +168,19 @@ def openbabel_mol_to_rdkit_mol(obmol: 'openbabel.OBMol',
         rw_mol.AddBond(atom1_idx, atom2_idx, ORDERS[bond_order])
 
     # Rectify the molecule
+    # fix C#N-R to be [C-]#[N+]-R
+    rw_mol.UpdatePropertyCache(strict=False)
+    for bond in rw_mol.GetBonds():
+        if bond.GetBondType() == Chem.rdchem.BondType.TRIPLE:
+            atom1 = rw_mol.GetAtoms()[bond.GetBeginAtomIdx()]
+            atom2 = rw_mol.GetAtoms()[bond.GetEndAtomIdx()]
+            if atom1.GetAtomicNum() == 7 and atom2.GetAtomicNum() == 6 and atom1.GetTotalValence() == 4:
+                atom1.SetFormalCharge(+1)
+                atom2.SetFormalCharge(-1)
+            elif atom2.GetAtomicNum() == 7 and atom1.GetAtomicNum() == 6 and atom2.GetTotalValence() == 4:
+                atom2.SetFormalCharge(+1)
+                atom1.SetFormalCharge(-1)
+
     if remove_hs:
         rw_mol = Chem.RemoveHs(rw_mol, sanitize=sanitize)
     elif sanitize:


### PR DESCRIPTION
I was trying to use open babel to parse xyz, interpret connectivity, and then create an atom mapped smiles. However, I keep running into this error `AtomValenceException: Explicit valence for atom # 4 N, 4, is greater than permitted` I think because open babel is leaving C#N as neutral which causes RDKit to crash. This PR adds a patch to `openbabel_mol_to_rdkit_mol` which fixes the issue. @xiaoruiDong can you review this PR and let me know if there's a better way to handle this error? Thanks :)


```
xyz_str="""C      -0.36408100    0.98431600   -3.37195000
C      -0.03350700   -0.39420800   -2.87710200
C      -1.05010500   -1.47569700   -3.07352400
C       2.29463400   -0.90065000   -3.70766700
N       1.24568900   -0.76369000   -3.18038600
H      -1.22236000    1.41742000   -2.85803300
H      -0.62425500    0.89488200   -4.43452700
H       0.48105600    1.66021200   -3.26957600
H      -2.00329000   -1.19413600   -2.62552200
H      -0.71793600   -2.41900800   -2.64331400
H      -1.20797300   -1.63004700   -4.14867900
C      -1.70593000    2.03178400    1.45065100
C      -1.82890000    1.69736300   -0.02415500
O      -1.44824900    0.32941900   -0.26785800
C      -0.11554300    0.07180800   -0.29980900
O       0.72367100    0.93118700   -0.34867400
C       0.14105500   -1.36513700   -0.04726300
C       1.38042000   -1.83093000    0.02565700
H      -2.05838100    3.04983100    1.62919500
H      -0.66751400    1.96935100    1.77496700
H      -2.30742700    1.34867400    2.05221000
H      -1.20984900    2.36194100   -0.62487000
H      -2.86297900    1.76965300   -0.35874400
H      -0.72723600   -1.98853700    0.12036700
H       2.21712800   -1.18644400   -0.20841200
H       1.58563500   -2.86115500    0.28392800"""

rdkitmol = RDKitMol.FromXYZ(xyz_str, header=False)
psmi = rdkitmol.ToSmiles(removeAtomMap=False, removeHs=False)
```