### PR TITLE
Final modules

### DIFF
--- a/rdmc/conformer_generation/ts_optimizers.py
+++ b/rdmc/conformer_generation/ts_optimizers.py
@@ -16,7 +16,7 @@ import pickle
 import os
 import subprocess
 from time import time
-from typing import Optional
+from typing import List, Optional
 
 from rdmc.external.gaussian import GaussianLog, write_gaussian_ts_opt
 from rdmc.external.orca import write_orca_opt
@@ -151,10 +151,17 @@ class SellaOptimizer(TSOptimizer):
         Returns:
             RDKitMol
         """
-        opt_mol = mol.Copy(copy_attrs=["KeepIDs"])
+        opt_mol = mol.Copy(copy_attrs=["KeepIDs", "FiltIDs"])
         opt_mol.energy = {}
         opt_mol.frequency = {i: None for i in range(mol.GetNumConformers())}
         for i in range(mol.GetNumConformers()):
+
+            if not opt_mol.FiltIDs[i]:
+                opt_mol.AddNullConformer(confId=i)
+                opt_mol.energy.update({i: np.nan})
+                opt_mol.KeepIDs[i] = False
+                continue
+
             if save_dir:
                 ts_conf_dir = os.path.join(save_dir, f"sella_opt{i}")
                 os.makedirs(ts_conf_dir, exist_ok=True)
@@ -246,10 +253,17 @@ class OrcaOptimizer(TSOptimizer):
         Returns:
             RDKitMol
         """
-        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs"])
+        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs", "FiltIDs"])
         opt_mol.energy = {}  # TODO: add orca energies
         opt_mol.frequency = {i: None for i in range(mol.GetNumConformers())}
         for i in range(mol.GetNumConformers()):
+
+            if not opt_mol.FiltIDs[i]:
+                opt_mol.AddNullConformer(confId=i)
+                opt_mol.energy.update({i: np.nan})
+                opt_mol.KeepIDs[i] = False
+                continue
+
             if save_dir:
                 ts_conf_dir = os.path.join(save_dir, f"orca_opt{i}")
                 os.makedirs(ts_conf_dir, exist_ok=True)
@@ -348,10 +362,16 @@ class GaussianOptimizer(TSOptimizer):
         Returns:
             RDKitMol
         """
-        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs"])
+        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs", "FiltIDs"])
         opt_mol.energy = {}
         opt_mol.frequency = {i: None for i in range(mol.GetNumConformers())}
         for i in range(mol.GetNumConformers()):
+
+            if not opt_mol.FiltIDs[i]:
+                opt_mol.AddNullConformer(confId=i)
+                opt_mol.energy.update({i: np.nan})
+                opt_mol.KeepIDs[i] = False
+                continue
 
             if save_dir:
                 ts_conf_dir = os.path.join(save_dir, f"gaussian_opt{i}")

--- a/rdmc/conformer_generation/ts_verifiers.py
+++ b/rdmc/conformer_generation/ts_verifiers.py
@@ -85,19 +85,19 @@ class TSVerifier:
             list: a list of true and false
         """
         time_start = time()
-        self.verify_ts_guesses(
-            ts_mol=ts_mol,
-            multiplicity=multiplicity,
-            save_dir=save_dir,
-            **kwargs
-        )
+        ts_mol = self.verify_ts_guesses(
+                ts_mol=ts_mol,
+                multiplicity=multiplicity,
+                save_dir=save_dir,
+                **kwargs
+            )
 
         if self.track_stats:
             time_end = time()
             stats = {"time": time_end - time_start}
             self.stats.append(stats)
 
-        return
+        return ts_mol
 
 
 class XTBFrequencyVerifier(TSVerifier):
@@ -137,7 +137,7 @@ class XTBFrequencyVerifier(TSVerifier):
             list
         """
         for i in range(ts_mol.GetNumConformers()):
-            if ts_mol.KeepIDs[i]:
+            if ts_mol.KeepIDs[i] and ts_mol.FiltIDs[i]:
                 if ts_mol.frequency[i] is None:
                     props = run_xtb_calc(ts_mol, confId=i, job="--hess", uhf=multiplicity - 1)
                     frequencies = props["frequencies"]
@@ -152,7 +152,7 @@ class XTBFrequencyVerifier(TSVerifier):
             with open(os.path.join(save_dir, "freq_check_ids.pkl"), "wb") as f:
                 pickle.dump(ts_mol.KeepIDs, f)
 
-        return
+        return ts_mol
 
 
 class OrcaIRCVerifier(TSVerifier):
@@ -198,7 +198,7 @@ class OrcaIRCVerifier(TSVerifier):
             save_dir (_type_, optional): The directory path to save the results. Defaults to None.
         """
         for i in range(ts_mol.GetNumConformers()):
-            if ts_mol.KeepIDs[i]:
+            if ts_mol.KeepIDs[i] and ts_mol.FiltIDs[i]:
 
                 # Create and save the Orca input file
                 orca_str = write_orca_irc(ts_mol,
@@ -259,7 +259,7 @@ class OrcaIRCVerifier(TSVerifier):
             with open(os.path.join(save_dir, "irc_check_ids.pkl"), "wb") as f:
                 pickle.dump(ts_mol.KeepIDs, f)
 
-        return
+        return ts_mol
 
 
 class GaussianIRCVerifier(TSVerifier):
@@ -314,7 +314,7 @@ class GaussianIRCVerifier(TSVerifier):
             save_dir (_type_, optional): The directory path to save the results. Defaults to None.
         """
         for i in range(ts_mol.GetNumConformers()):
-            if ts_mol.KeepIDs[i]:
+            if ts_mol.KeepIDs[i] and ts_mol.FiltIDs[i]:
 
                 # Create folder to save Gaussian IRC input and output files
                 gaussian_dir = os.path.join(save_dir, f"gaussian_irc{i}")
@@ -395,7 +395,7 @@ class GaussianIRCVerifier(TSVerifier):
             with open(os.path.join(save_dir, "irc_check_ids.pkl"), "wb") as f:
                 pickle.dump(ts_mol.KeepIDs, f)
 
-        return
+        return ts_mol
 
 
 class TSScreener(TSVerifier):


### PR DESCRIPTION
## Description
This PR enables the current TSConformerGenerator object to run some final modules, including TSOptimizer or TSVerifier, in a different level of theory than the one used for generating TS conformers. Besides, a filter function was added. This function will rank the existing conformers by their energies and users can choose the top N with the lowest energies to be passed for the following steps. The number of reactions to be passed to the following steps of verifiers and final_modules can be defined by giving the values of `n_verifies`  and `n_refines`  when calling the TSConformerGenerator object. The calculation results of final_modules will be saved in a folder called final_modules.

## Example
        final_modules = [
            GaussianOptimizer(
                method=args.reopt_method,
                nprocs=args.nprocs,
                memory=args.memory
            ),
            XTBFrequencyVerifier(),
            GaussianIRCVerifier(
                method=args.reopt_method,
                nprocs=args.nprocs,
                memory=args.memory,
                fc_kw="CalcFC,ReCalc=7"
            )
        ]

        ts_gen = TSConformerGenerator(
            rxn_smiles=rxn_smiles,
            embedder=embedder,
            optimizer=optimizer,
            pruner=pruner,
            verifiers=verifiers,
            final_modules=final_modules,
            save_dir=save_dir
        )

        _ = ts_gen(args.n_ts_conformers, args.n_ts_verifies, args.n_ts_refines)

where the args.reopt_method is the method used for further reoptimization and verification for conformers obtained from lower-accuracy calculations, args.n_ts_verifies and args.n_ts_refines are the values of n_verifies  and n_refines  passed to the TSConformerGenerator object.

