### PR TITLE
Remove FilterIDs

### DIFF
--- a/rdmc/conformer_generation/sampler.py
+++ b/rdmc/conformer_generation/sampler.py
@@ -291,7 +291,6 @@ class TorsionalSampler:
         multiplicity = minimum_mols.GetSpinMultiplicity()
         self.logger.info("Optimizing guesses...")
         minimum_mols.KeepIDs = {i: True for i in range(minimum_mols.GetNumConformers())}  # map ids of generated guesses thru workflow
-        minimum_mols.FiltIDs = {i: True for i in range(minimum_mols.GetNumConformers())}  # map ids of generated guesses thru workflow
 
         if rxn_smiles:
             opt_minimum_mols = self.optimizer(

--- a/rdmc/conformer_generation/ts_optimizers.py
+++ b/rdmc/conformer_generation/ts_optimizers.py
@@ -154,15 +154,14 @@ class SellaOptimizer(TSOptimizer):
         Returns:
             RDKitMol
         """
-        opt_mol = mol.Copy(copy_attrs=["KeepIDs", "FiltIDs"])
+        opt_mol = mol.Copy(copy_attrs=["KeepIDs"])
         opt_mol.energy = {}
         opt_mol.frequency = {i: None for i in range(mol.GetNumConformers())}
         for i in range(mol.GetNumConformers()):
 
-            if not opt_mol.FiltIDs[i]:
+            if not opt_mol.KeepIDs[i]:
                 opt_mol.AddNullConformer(confId=i)
                 opt_mol.energy.update({i: np.nan})
-                opt_mol.KeepIDs[i] = False
                 continue
 
             if save_dir:
@@ -256,15 +255,14 @@ class OrcaOptimizer(TSOptimizer):
         Returns:
             RDKitMol
         """
-        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs", "FiltIDs"])
+        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs"])
         opt_mol.energy = {}  # TODO: add orca energies
         opt_mol.frequency = {i: None for i in range(mol.GetNumConformers())}
         for i in range(mol.GetNumConformers()):
 
-            if not opt_mol.FiltIDs[i]:
+            if not opt_mol.KeepIDs[i]:
                 opt_mol.AddNullConformer(confId=i)
                 opt_mol.energy.update({i: np.nan})
-                opt_mol.KeepIDs[i] = False
                 continue
 
             if save_dir:
@@ -365,15 +363,14 @@ class GaussianOptimizer(TSOptimizer):
         Returns:
             RDKitMol
         """
-        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs", "FiltIDs"])
+        opt_mol = mol.Copy(quickCopy=True, copy_attrs=["KeepIDs"])
         opt_mol.energy = {}
         opt_mol.frequency = {i: None for i in range(mol.GetNumConformers())}
         for i in range(mol.GetNumConformers()):
 
-            if not opt_mol.FiltIDs[i]:
+            if not opt_mol.KeepIDs[i]:
                 opt_mol.AddNullConformer(confId=i)
                 opt_mol.energy.update({i: np.nan})
-                opt_mol.KeepIDs[i] = False
                 continue
 
             if save_dir:

--- a/rdmc/conformer_generation/ts_verifiers.py
+++ b/rdmc/conformer_generation/ts_verifiers.py
@@ -137,7 +137,7 @@ class XTBFrequencyVerifier(TSVerifier):
             list
         """
         for i in range(ts_mol.GetNumConformers()):
-            if ts_mol.KeepIDs[i] and ts_mol.FiltIDs[i]:
+            if ts_mol.KeepIDs[i]:
                 if ts_mol.frequency[i] is None:
                     props = run_xtb_calc(ts_mol, confId=i, job="--hess", uhf=multiplicity - 1)
                     frequencies = props["frequencies"]
@@ -198,7 +198,7 @@ class OrcaIRCVerifier(TSVerifier):
             save_dir (_type_, optional): The directory path to save the results. Defaults to None.
         """
         for i in range(ts_mol.GetNumConformers()):
-            if ts_mol.KeepIDs[i] and ts_mol.FiltIDs[i]:
+            if ts_mol.KeepIDs[i]:
 
                 # Create and save the Orca input file
                 orca_str = write_orca_irc(ts_mol,
@@ -315,7 +315,7 @@ class GaussianIRCVerifier(TSVerifier):
             save_dir (_type_, optional): The directory path to save the results. Defaults to None.
         """
         for i in range(ts_mol.GetNumConformers()):
-            if ts_mol.KeepIDs[i] and ts_mol.FiltIDs[i]:
+            if ts_mol.KeepIDs[i]:
 
                 # Create folder to save Gaussian IRC input and output files
                 gaussian_dir = os.path.join(save_dir, f"gaussian_irc{i}")


### PR DESCRIPTION
In the PR in #34, a `FilterIDs` is added in RDKitMol object during TS conformers generation, but the `KeepIDs` can actually do what `FilterIDs` is supposed to do. Hence, the `FilterIDs` is removed in this PR.