### PR TITLE
Fix single-atom openbabel mol to rdkit mol

### DIFF
--- a/rdmc/test/test_utils.py
+++ b/rdmc/test/test_utils.py
@@ -8,7 +8,9 @@ import logging
 import unittest
 
 import numpy as np
-from rdmc.utils import reverse_map
+from rdmc.utils import (parse_xyz_by_openbabel,
+                        reverse_map,
+                        openbabel_mol_to_rdkit_mol)
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -32,6 +34,22 @@ class TestUtils(unittest.TestCase):
 
         self.assertSequenceEqual(r_map, reverse_map(map))
         np.testing.assert_equal(np.array(r_map), reverse_map(map, as_list=False))
+
+    def test_openbabel_mol_to_rdkit_mol_single_atom_xyz(self):
+        """
+        Test if a single-atom openbabel mol with all-zero xyz coordinates can be successfully converted to rdkit mol with a conformer embedded.
+        """
+        xyz = '1\n[Geometry 1]\nH      0.0000000000    0.0000000000    0.0000000000\n'
+        obmol = parse_xyz_by_openbabel(xyz)
+        rdmol = openbabel_mol_to_rdkit_mol(obmol)
+
+        self.assertEqual(rdmol.GetNumConformers(), 1)
+        self.assertEqual(rdmol.GetNumAtoms(), 1)
+        self.assertTrue(np.array_equal(
+                                rdmol.GetConformer().GetPositions(),
+                                np.array([[0., 0., 0.,]])
+                                )
+                        )
 
 
 if __name__ == '__main__':

--- a/rdmc/utils.py
+++ b/rdmc/utils.py
@@ -174,7 +174,7 @@ def openbabel_mol_to_rdkit_mol(obmol: 'openbabel.OBMol',
         Chem.SanitizeMol(rw_mol)
 
     # If OBMol has 3D information, it can be embed to the RDKit Mol
-    if embed and obmol.HasNonZeroCoords():
+    if embed and (obmol.HasNonZeroCoords() or obmol.NumAtoms() == 1):
         coords = get_obmol_coords(obmol)
         conf = Chem.rdchem.Conformer(coords.shape[0])  # Create a conformer that has number of atoms specified
         set_rdconf_coordinates(conf, coords)


### PR DESCRIPTION
Previously, in PR #45, Shih-Cheng mentioned a bug when reading a Gaussian log file with a single atom calculation. It turned out that this was due to issues in converting the perceived OBMol to RDKit Mol. obmol.HasNonZeroCoords() was used as a flag to check if a 3D geometry is included in the OBMol, but it is not helpful for single atom molecule.