### PR TITLE
Rename the package and update its requirement in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
-# RDMC (RDkit Molecule and Conformer)
+# RDMC (Reaction Data and Molecular Conformer)
 
 [![Documentation Status](https://readthedocs.org/projects/rdmc/badge/?version=latest)](https://rdmc.readthedocs.io/en/latest/?badge=latest)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
-A light-weight wrapper for RDKit Mol and Conformer related operation. RDKit has many modules and people often complain about having difficulty to identify functions to be used.
-Hopefully, this repository can make life easier and let people know how to make use of each RDKit function. For detailed APIs, please check the [documentation](https://rdmc.readthedocs.io).
+A light-weight software package with expertise in handling Reaction Data and Molecular (including transitions states) Conformers. For detailed APIs, please check the [documentation](https://rdmc.readthedocs.io).
 
 ## Requirements
 * python
 * numpy
-* openbabel
+* scipy
 * rdkit
+* openbabel
 * py3dmol
 * ase
-* pygsm-gaussian
-* scine-sparrow
+* networkx
+* matplotlib
+* cclib
 
 ## Demos
 Feel free to check demos in the `ipython/` to learn some basic use of RDMC repository


### PR DESCRIPTION
This discussion may be more proper to be put in the issues tab, but since we only have a few (5) active developers, I just opened a PR and listed everyone as a reviewer (@PattanaikL @shihchengli @kspieks @hwpang .

Here, I want to propose a new interpretation for RDMC. The original interpretation is an RDKit Wrapper for molecules and conformers, and the original scope of RDMC was indeed a wrapper for RDKit to simplify how we use RDKit. But as of today, the functionality of RDMC has greatly expanded thanks to everyone's effort. It might be a good time to change its interpretation. 

1. I don't have a strong impetus to change the acronym "RDMC". I think we probably want to use the same abbreviation, as it is already a name we advertise at places (conferences, meetings, talks). Changing "RDMC" will also involve changing the module names and potentially break people's current code/workflow. 

2. I am proposing "Reaction Data and Molecular Conformer" as a candidate. I will say this helps summarize the most essential functionalities and use cases achieved by RDMC. I am pretty open to other suggestions and we can vote to decide which new interpretations are better.

Let me know your thoughts and suggestions.

P.S. this PR modifies the README file, where I just changed the "Requirement" Section to make it consistent with `environment.yml`. 

