### PR TITLE
Enable Creating Atommapped Reaction SMILES with RXNMapper

### DIFF
--- a/ipython/Generate Atommapped SMILES.ipynb
+++ b/ipython/Generate Atommapped SMILES.ipynb
@@ -2,64 +2,92 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "b496892f",
    "metadata": {},
    "source": [
     "# Generate Atom-mapped SMILES for RMG reactions.\n",
-    "This notebook helps create atom-mapped SMILES for reactants and products that belong to a RMG reaction family."
+    "This notebook helps create atom-mapped SMILES for reactants and products. Two methods are available:\n",
+    "\n",
+    "1. Atommapping according to the templates of RMG reaction families.\n",
+    "2. Atommapping using RXNMapper and in-house H atom mappings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3931e00d",
+   "metadata": {},
+   "source": [
+    "## Import Modules"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "e42b30f5",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:root:No normalization for BCUT2D_MWHI\n",
-      "WARNING:root:No normalization for BCUT2D_MWLOW\n",
-      "WARNING:root:No normalization for BCUT2D_CHGHI\n",
-      "WARNING:root:No normalization for BCUT2D_CHGLO\n",
-      "WARNING:root:No normalization for BCUT2D_LOGPHI\n",
-      "WARNING:root:No normalization for BCUT2D_LOGPLOW\n",
-      "WARNING:root:No normalization for BCUT2D_MRHI\n",
-      "WARNING:root:No normalization for BCUT2D_MRLOW\n"
+      "Importing RMG modules...\n",
+      "This step may takes a while...\n",
+      "Importing RXNMappers modules...\n"
      ]
     }
    ],
    "source": [
     "import os\n",
     "import sys\n",
-    "# To add this RDMC into PYTHONPATH in case you haven't do it\n",
+    "# To add RDMC into PYTHONPATH in case you haven't done\n",
     "sys.path.append(os.path.dirname(os.path.abspath('')))\n",
     "\n",
     "from rdmc.mol import RDKitMol, parse_xyz_or_smiles_list\n",
+    "from rdmc.ts import get_formed_and_broken_bonds\n",
+    "from rdmc.reaction import Reaction\n",
     "\n",
+    "# Import RMG dependencies\n",
+    "# You can install RMG according to http://reactionmechanismgenerator.github.io/RMG-Py/users/rmg/installation\n",
+    "# Loading RMG may take a while\n",
     "try:\n",
-    "    # import RMG dependencies\n",
+    "    print('Importing RMG modules...')\n",
+    "    print('This step may takes a while...')\n",
     "    from rdmc.external.rmg import (from_rdkit_mol,\n",
     "                                   load_rxn_family_database,\n",
     "                                   generate_reaction_complex,)\n",
     "    # Load RMG database\n",
     "    database = load_rxn_family_database(families='all')\n",
     "except (ImportError, ModuleNotFoundError):\n",
-    "    print('You need to install RMG-Py first and run this IPYNB in rmg_env!')\n",
+    "    print('You need to install RMG to use RMG for atommapping!')\n",
     "\n",
+    "    \n",
+    "# Import RXNMapper\n",
+    "# You can install RXNMapper by `pip install rxnmapper`\n",
+    "try:\n",
+    "   \n",
+    "    print('Importing RXNMappers modules...')\n",
+    "    from rxnmapper import RXNMapper\n",
+    "except (ImportError, ModuleNotFoundError):\n",
+    "    print('You need to install RXNMapper to use RXNMapper for atommapping!')\n",
+    "    \n",
     "%load_ext autoreload\n",
     "%autoreload 2"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "2b0ef8be",
    "metadata": {},
    "source": [
     "## Examples\n",
+    "You can choose whichever reaction you like, and you are encouraged to provide your own example.\n",
+    "\n",
     "For carbenes and biradicals, you need to specify the multiplicity as well. E.g., `reactants=[('[CH2]', 1)]`"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "6c9b52f3",
    "metadata": {},
    "source": [
     "H_migration"
@@ -68,17 +96,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "26abbfab",
    "metadata": {},
    "outputs": [],
    "source": [
     "reactants = [\n",
     "\"\"\"[CH2]CCCCO\"\"\",]\n",
     "products = [\n",
-    "\"\"\"CCCCC[O]\"\"\",]"
+    "\"\"\"[O]CCCCC\"\"\",]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "f05d72e2",
    "metadata": {},
    "source": [
     "Retroene"
@@ -87,11 +117,12 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "80c92963",
    "metadata": {},
    "outputs": [],
    "source": [
     "reactants = [\n",
-    "\"\"\" C1=CC(C2C=CCC2)C=C1\"\"\",]\n",
+    "\"\"\"C1=CC(C2C=CCC2)C=C1\"\"\",]\n",
     "\n",
     "products = [\n",
     "\"\"\"C1=CC=CC1\"\"\",\n",
@@ -100,6 +131,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3e3bb1a1",
    "metadata": {},
    "source": [
     "H abstraction"
@@ -108,6 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "42903c1d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,6 +155,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "55d4a802",
    "metadata": {},
    "source": [
     "1+2_Cycloaddition"
@@ -130,6 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "5cfe26b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,6 +178,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0f82f0f0",
+   "metadata": {},
+   "source": [
+    "H2_elimination"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "946ea3b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reactants = [\n",
+    "    \"\"\"CC\"\"\", ]\n",
+    "\n",
+    "products = [\n",
+    "    \"\"\"C=C\"\"\",\n",
+    "    \"\"\"[H][H]\"\"\",]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d20e9b2",
    "metadata": {},
    "source": [
     "1,2_Insertion_carbene"
@@ -150,7 +209,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
+   "id": "20aebbcb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,25 +219,37 @@
     "    \"\"\"C=C\"\"\", ]\n",
     "\n",
     "products = [\n",
-    "    \"\"\"CC=C\"\"\", ]\n"
+    "    \"\"\"CC=C\"\"\", ]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "d3250a39",
    "metadata": {},
    "source": [
-    "## Generate reactant and product complex"
+    "# [Method 1] Atommapping using RMG"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 8,
+   "id": "f43345b5",
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You can neglect the Open Babel Warnings below.\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "==============================\n",
+      "*** Open Babel Warning  in ReadMolecule\n",
+      "  Problems reading an XYZ file: The first line must contain the number of atoms.\n",
       "==============================\n",
       "*** Open Babel Warning  in ReadMolecule\n",
       "  Problems reading an XYZ file: The first line must contain the number of atoms.\n",
@@ -190,13 +262,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[CH2]CCCCO <=> CCCCC[O]\n",
-      "RMG family: intra_H_migration\n",
+      "C=C + [CH2] <=> C=CC\n",
+      "RMG family: 1,2_Insertion_carbene\n",
       "Is forward reaction: True\n"
      ]
     }
    ],
    "source": [
+    "print(\"You can neglect the Open Babel Warnings below.\")\n",
     "try:\n",
     "    # Generate RMG Molecule\n",
     "    r_mols = parse_xyz_or_smiles_list(reactants)\n",
@@ -222,67 +295,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e9acff97",
    "metadata": {},
    "source": [
-    "### Generate SMILES"
+    "### Generate Reaction SMILES"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Reactant"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['[C:1]([C:2]([C:3]([C:4]([C:5]([O:6][H:17])([H:15])[H:16])([H:13])[H:14])([H:11])[H:12])([H:9])[H:10])([H:7])[H:8]']"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "r_complex.ToSmiles(removeAtomMap=False, removeHs=False).split('.')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Product"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['[C:1]([C:2]([C:3]([C:4]([C:5]([O:6])([H:15])[H:16])([H:13])[H:14])([H:11])[H:12])([H:9])[H:10])([H:7])([H:8])[H:17]']"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "p_complex.ToSmiles(removeAtomMap=False, removeHs=False).split('.')\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "id": "157aad6a",
    "metadata": {},
    "source": [
     "Visualize reactant and product in molecule graphs"
@@ -290,49 +311,540 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
+   "id": "b5dea04d",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO2dZ1xTydfHT+idUAQRGwgoqKuwYoF1BVTECuiiKDZExS72gg0LolhQFNEFK+pjRXRVFBAFuwgCFkCw0KSThAQIJfd5Mbv5Z5MQKWk3e78fXiQzcye/e8mcTDlzhoRhGBAQEBAQtBc5SQsgICAgwDeEGSUgICDoEIQZJSAgIOgQhBklICAg6BCEGSUgICDoEAqSFkBA8B+isrKysbFRV1dXSUmJN7e6uprJZGpra6uqqvK9nMViFRQUdOvWTU7uXx2gurq6+vp63vKqqqoqKipCUU4gAKI3SkAgPkaMGGFkZBQfH88319PT08jIKCoqijertrY2PDzc0tKyZ8+e9vb2XLnLly/X5ce5c+eEfw8EPBC9UQICqaakpOT48ePh4eEVFRUopbGxkavMjx8/AMDBwaFTp06c6YMGDRKPyP84hBklIJBqHj9+HBgYOHjw4DVr1mhqai5btoy3THFxMQCEhob269dP7AIJCDNKICusXLmyvLx827Ztffr04c3dsWNHTk7O8uXLhw0bxptLp9PPnDmTlJQ0evTohQsXtvQRLBZrxYoVZWVlADBixIilS5cKUX9LuLu7FxYWGhkZAcDDhw/5lkFmtEuXLmLQQ8ALYUYJZISYmJjv378vWrSIrxl9+PDhixcvJk6cyGVGS0pKwsPDQ0NDq6qqAKCiokKAGT1x4sTx48cVFBSamprU1NSEfgt8UVZWRja0JRobGysqKpSVlXV0dMQjiYALYomJ4L/L+fPnu3fvHhAQoKKi8vvvvwsuXFxc7O/vr6qq6uvrKwZtPj4+Xl5enz59+mnJ0tJSFotlZGSEYVhubu6rV69yc3OJWBnihOiNEvyc9PT0pqYmKysrvo44nz59qq2tNTMz09bW5ns5lUr99OmTpaVlSwWQsTA3N1dQEOsX0tbWdu3atW5ubra2ttHR0UlJSQIKL1myhEqlBgYGKisrd/Bzb968+fHjR970b9++sV9fuXKFwWDMnz/f0tJScG1ofamystLY2LikpAQlmpubBwYG/vHHHx2UStAaCDNK8HOcnJyqqqrevn1rY2PDmztt2rTMzMw7d+5MmDCBK+vHjx8nT548evRodXX1hAkT7ty5w1Xg6dOn+/btu3v3LoZhN2/edHd3F9U98MPS0jIwMLA1JS9fvhwTE9O3b9+1a9eGhoZ28HMjIyN/Wmbp0qVMJrNbt24/Lamjo2Ntbd3U1DRq1KgePXpUVlY+ePDg9evXHh4ep06dWrBgQQfVEvwUwowSiIT09PTAwMCbN282NTXxLRAZGXn48OEPHz6IWRgAvH37FgAsLS1bOb9ZWVnp5+dHIpFOnjypqKjYcQFbt27l+4MUEBDw7t079Hrfvn2trM3MzCw1NZWrnsDAwC1btqxZs8bT01NTU7ODggkEQ5hRApHw6tWruLg4d3f3CRMmUKnUFStWcBU4depUXV3dihUrPDw8Nm3a9PTpU6F8LoZhLBZLcBnkTfn69WtbW9vW1Llq1aqysrKFCxfy+r23j6FDh44bN443/cSJE0Kpn0Qibdy4cd++fTU1NQkJCW5ubkKplqAlCDMqYVxdXRsbGyMiIvh6q/j4+Pz48WPfvn39+/fnzS0qKgoNDU1NTfX09Jw3bx5XLpPJDA8Pj4mJKSoqUlZWtra29vX1tbOzE8lt8DB37lxvb2/Ud+O7lyYxMZHdGeTa2tgRHBwchFUV4tGjR1FRUfr6+nv27BFuzSJFXl7e3Nw8NTUV+UIRiBTCjEqY2NjYhoYGBoPBNzcxMfHr16/r16/nSk9PTw8LCzt//jzaSa2np8dlRqurqx0dHdPT0wHAwMCgpqYmMzMzKioqODh49erVormVf8F3zzgnInIY+uWXX/guZKWnp9NoNPS6ubkZWme7a2trFyxYgGFYSEiIvr6+cKWKmsLCQgAwNDSUtBDZh3B4wh+BgYEDBw48deqUpaWlo6Mj3zILFy5MT0/v1atXSkpKaWlpdXV1UFAQhmFr165NTk4WkbC6ujoHBwcHB4f8/HwRfcRPCQ0NTeJH37592WXk5ORa2f/dvHnzly9fHBwcZsyYITLJ/KmpqaHRaMjiC+bLly9HjhzhSrxy5UpZWZmKispvv/0mGoEE/4PojeIPFxcXDQ0NV1fXHj16HD9+PDExkatAZmbmjRs3SCTS9evXBw4cCADKysobNmzIyck5ffr0zp074+Li2vG5Bw8eNDAw4E1HDjcA0Nzc/OTJEwBoqXONL169enXs2DEAsLW1/fPPP9npL1++BICcnJxTp079+uuvv/76qyg+3cjIiMFgPHr0CI0qysvLASAtLQ0AaDQaCm6iqqo6ZMiQiRMnfvz4MSYmZunSpTY2NjQa7c6dO3v37gWA9evXE71RMUCYUfxhY2PDd52XzY0bNzAMc3JyQjaUzcqVK0+fPp2YmFhRUdGOIeqlS5cEF1BWVt6/fz/IykDyzp07qDMYHBzMm/vixYsXL15s375dRGaUk23btt2+fZv99vPnz6NHjwYAU1PTvLy8M2fOeHt7JyYmcv6gKigo+Pv779ixQ9TaCIAwo3ihoaEBDcZ/++23n7p/v3nzBgCGDx/Old6/f38ymUyhUFJTU52dnduq4cKFC7179+ZNnzFjRm5uLgAoKiquW7eurdVKLa6urt27d+dNj4+Pv3bt2rBhw+bOndtWG7pgwYKSkpJevXrxzfX09LSxsUE/fmlpaSwWCwmYPHkyXyd8XV1dABg8eHBGRkZcXFxcXFxRUZGSklLfvn09PDxMTU3bpI2g3RBmVCqgUqloTzcXbN+dqqqqUaNGAUB+fv5PXbKRUevcuTNXOolE6ty5M4VCycvLa4dIKysrvr3glmIMSy3z588HgC1btvTs2VNAMVtbW74eUXQ6/dq1axYWFgJ237fEypUrOd/W1dXFx8djGDZp0iQA8Pb2ZmeZm5uzX8+ZM0dwtfLy8i4uLi4uLm3VQyAUCDMqFfzUgVFOTg45UbdmbQQtSfOdxzQwMMjKymKvWf83QZuIfH19e/bsuXjxYtR5p1AoAPD27VvkVWpubn758mVRK6murp40aVKXLl2QGSXAKYQZlQqcnJzU1dV50xMSEmprawHAwMCg9bYPhaXga3Dl5eWBo5MrSygrKyspKbX0M6OkpKSkpIRuH/Ui0c9MTk4O2tSEqKmpQW95QyOLAjKZDP9YcAL8QphRqSA8PJxzEMfG1NT069evba1NU1OztLQUre1ygRK1tLTaIfKnYBiWlZUFAL169fqp36jQyc7OFpD7+PFj9uuTJ0+yXyckJLT1g1avXi0s31s1NTVlZeXa2lomk9nxiCcEkoIwozJIjx49cnNzUXRhLkpLSwFA8Jxgu2EwGFZWVgDw8eNHS0vLhIQENOGLRs3FxcXXrl0DAH19fUdHRyqVyg5CjIz78+fP0Qb8QYMGmZiYdFBMXl6ei4uLsbExpwGVQrS1tcvKyqhUKt9JGAJcQJhRGcTGxiYhIQEZL06+fftWXl5OIpGsra3FIGPz5s2vX79mv01NTZ06dSoA2NvbP336ND8/H71lc+DAAfQiMjKy42ZUUVExNze3oaGhg/WIGjKZXFZWRqFQCDOKX0RoRj99+lRSUmJqatqjRw/e3C9fvnz//t3Y2NjCwgKlMBiMFy9eCKjQ1ta2pYCVBJxMmjQpODg4Nja2uLiYc6v+6dOnAWDw4MFtPW1i//799fX1fL1/AMDf37+ioqJ///4aGhp0Oh3+2ei5adMmvj1i5EJgbGzMObjmRCgRQPAy7YgXnQSCwETGzJkzAWDXrl18czds2AAAixcvZqf8NND3y5cvRadWUqA5xJycHL65qFOWmJhYXV09ZcqUKVOmVFRUcBZA22w8PT25LkSWaMSIEdXV1Sjl4cOHaPYtOjq6g5qLi4uPHz8eFRXVwXpECovFkpeXJ5FIjY2NktYiCOTA++DBA0kLIWg/UjSo19PTQ7aVi9ra2tDQUHl5ecEn0sg29fX1N27cAIDDhw/r6emNGTMGOYei5fu//voLeXQPHz787NmzAHDu3Dk7O7snT5707Nlz2LBhFRUVKSkpAODr69vxsGk/fvxYunTpwIEDvby8OliV6CCRSNra2lVVVTQaDbmpSydEb1QGkCIz2qlTp6CgIN7048ePQ8tbSvCOoaEhk8ls6fAMfX19BoOhpKSkoaGB4jyhRXYajVZdXY3KoIPM0Fs0pgaAXr16paWlbdmy5datW7GxsSQSacCAAcuXL+eNp9cO8NLyyWRyVVUVhUIhzCiBSJEiM8oXFosVEhICAGvWrJG0FpEgOBgS5xINZzh0wZPIiC5dupw+ffr06dN0Ol1ZWVkoYdsReGn5uNCJC5EEgpH2QHm3bt3Kzc21tbUVW7xhyfLs2TM9Pb12bHgXgIaGhhBtKABoa2uTSCQajSblbvy4sFBo1ZRKpUpaCEH7kQozOn/+fBsbm6ioKN6sgwcPAgBv3GJZRUlJqaqqiu/+eulBXl5eU1OTxWJJ+aZSXJhRXIgkEIzIB/W3bt3iuw8HrXggcnJy0tLSkGc4J2/evHn+/HnPnj3/O4fJ4KVRkclkGo1GoVCQYOkEFw+Tc2qbAKeI3Iy+ffuWc88yX9auXevl5TVs2DCudBS80s/PT8zHl0sQXLR8ACCTyfn5+VKuExcWCi//cQIBiNw8rVy5cvHixbzpBw8eZEcU5xve5uvXr9HR0VpaWpzRw2QedqPCMIxEIklaTovgovHjYtoRF0+SQDAiN6P6+vp8Y/3+1Afl8OHDzc3NixYtElEcDelEUVFRXV2dwWDQ6XRpPl4cF42fEEkgHqRiiYmX6urqM2fOKCoqLlu2TNJaxA0u2hUhUljgQiSBYKTUjIaHh9Pp9GnTpv000rvsgYt2RYgUFrgQSSAYqVi6+fTpE41G69GjBwpa0djYGBYWBgDiOVFd2sBFuyJECgtVVVVlZeW6ujoi5Ch+kYreqK+v79ChQy9evIjeXrx4sbCw0MnJSTzx3KQNXDR+YvVGiOBFJ0FLSIUZlZOTI5FI7IVp2d79+VNw0agIkUIELzoJWkKEg/pFixaNHj26pR7ltGnTrKys0CI+Z3xyGo22ZMkSeXn5sWPH8l7FYrFac6YbrsFFoyJEChG86CRoCRGaUXt7ewHxd62trflaWC0trZbOrX3+/PnChQvPnTvX1sPB8QUuGhUuRGpoaCgoKNDp9KamJmnewYGLh0kgADz17K5cufLhwwcfHx/pPxmiIxDTjsIChRzFMIx4mAQiBU9mdO/evWZmZunp6Xv37pW0FhGCi0aFC5GAE524EEkgADyZUTU1tbNnz8rJye3evTs1NVXSckQFLhoVLkQCTnTiQiSBAPBkRgHA3t5+yZIlTU1N8+bNa2xslLQckYCLRkWEHBUiuJjGIRAAzswoAOzbtw8N7fmeOCID4KLlEyFHhQguRBIIAH9mVE1N7c8//ySRSLt3787MzJS0HOGDl0aFC52ESAIxgD8zCgAODg6LFy9uaGiYM2eO7A3t8dKocKGTEEkgBnBpRgFg//796PDL4OBgSWsRMpwhRyWtRRC4aPy4mHbExZMkEABezai6ujoa2u/cufP9+/eSliNMUMjR5uZm9mnJ0gkuGj8RAJ9ADODVjAKAo6Ojr68vk8mcPXu2jA3tcdGuCJHCAhciCQSAYzMKAAcOHDA1NU1LS0MHiMoMuGhXhEhhgQuRBAKQ3o3GrQEN7UeNGrVjx46JEyf27dtX0oqEAy7aFSFSWOAg5GhNDcTFwdu3UFkJysrQtSuMHAk2Nq26NiMDYmOhsBAAoGdPGD8e+J0qhGvwbUYBwMnJacGCBadOnfLx8Xn27Jm8vLykFQkBXDR+YvVGiJDJ5NLSUgqFYmhoKGktPISFwdatUFXFne7gAH/+CWZmLV5YWgrz58Nff/0rce1auHcPXFyEr1Ny4N6MAkBwcHBsbOyrV68OHjy4fv16ScsRArho/MTqjRCZNm1afX29NIah2roVdu8GOTmYPRs8PaFHD6ithVev4PBhePwY7O0hKYl/75JGAycn+PgRTE1h3ToYMgTk5SErC5KTwdlZ7LchYjCZID4+nkQiKSsrv3//XtJahMDSpUsB4OjRo5IWIoibN28CgKurq6SFCKKmpgYANDQ0JKiByWQWFBRkZWWVl5dLUEZ7SEjASCRMTg6LjubOotOxESMwAGzQIIzF4nPt8uUYANa3L1ZVJQalkgXfS0xsRo4c6ePjw2QyfXx8mpubJS2no+CiD4ULkRoaGoqKinQ6XSK+HE+fPp04caKOjk63bt369OnTqVOnPn36HDlyhO9X9N69eyR+jB49WvzK/2bvXsAw8PUFNzfuLHV1uHgRVFUhJQUePuTOpdEgMhIA4OhR0NERh1SJIn2DiPZy8ODBhw8fvnr16vDhw2vXrpW0nA5BTDsKEW1t7YqKCiqVqq+vL87P3bVr1/bt2zEM09bWHjt2rJaWVkFBwcuXL/38/O7fvx8TE8O1mlRSUgIA3bp16/3vMbKzpIbAVCo8egQA4OvLv4CxMbi7w6VLEB0NY8b8KysuDmprwdgYHB1FrlMKkB0zqqWlFRkZ6ezsvGXLlnHjxllZWUlaUfvBhYXChUgAeP/+vYaGhrq6ujg/9NKlS9u2bQOA9evXBwQEqKiooPSsrKxp06YxmUwGg8FlRouKigBg3rx5O3bsEKfUFnn7Flgs0NCA/v1bLGNvD5cuwZs3AACnToGvLwwcCGlp8O4dAMDgwUAiwYsXkJAAFAp06QJubmBqKib9YkR2zCgAjBo1ytvb+/Tp0z4+Pk+fPsXvqj0uLJRkRRYXF9+6dev169cVFRWqqqpmZmbu7u6DBw/mLcm19l1fX7979+6mpiYAGDt27IgRI4SurbGxcd26dQDg6+u7b98+zqw+ffokJiZqamoqKipyXfXjxw8A6NKli9D1tIGGBqBQgEIBMhlKSwEAjIxAwOlnXbsCwN8lOSkqAgBobobff4fk5P+lr1sHW7eClPxOCA+ZMqMAcOjQobi4uJcvXx45cgS/x9zjwoxqa2vLycnRaLTm5mZx/mJhGLZ79+69e/fW1dVxpgcFBXl6ekZGRqqpqQm4fOfOnXv37pWTk2OxWLq6uqIwo3FxccXFxQoKCjt37uTN1dXV5XsVMqNGRkZCVNLQ0CBHpSpUVwOV+rd9rK7++wX7j51FoUBt7d9X7t0LnTsDAAj2Y0W97Pp6AAB3d7C2BtTrr6kBALh9G3r0gKAgsLcHJhPu3IFjxyAgALp3h3nzhHibEkfWzKi2tnZ4ePj48eP9/f3Hjh1raWkpaUXtARdmVE5O7vz58xoaGmL+3DVr1hw+fJhEIs2ePXvevHlmZmZ1dXVJSUm7du36v//7v169eu3evbulazMyMg4cOKCvr29vbx8TEyMihS9evACAIUOGGBgYCCjGYrFQp3XNmjVdunRhm1Emk1lWVqakpMTXh7Surq66FdTX19fV1ZWUlJQOGtQJDbpbg4ICkMlAJoOmJmhpAQAIDuyAzKW2NgBAp07QqdPf6ehn1dER7t4FVdW/E0eOBHV1CAyEoCDCjEo748aNmzt37tmzZ318fJKTk/E4tJcGM1pcXPz9+/e6ujoDAwNLS0u+j9HLywu9qKmpycvLo9FoPXr06Nq1q+ieeVJSUkhICACEhYUtWrSInW5mZubm5nb8+PGNGze2dG1zc7OPj09jY+Phw4c5z/QWOl+/fgWAn/6ENzc3Hzp0CABmzZrFNqMrVqxITU1lMpkA0KNHDz8/vxUrVqBDxXv37p2Tk9MmJQoKCjVkcqdevYBMBh2dv00k55+29r/ecv4ovn0LAFBYCHV1/zOFXGRnAwD07MmdjkywsTH3hTNmQGAgfP4M1dWytIIvg2YUAEJCQuLj41+8eBEaGurn5ydpOW1GgmYUw7CoqKjg4GDOkNh6enqLFi3y9/dX5WlO1dXVmzdvPnv2bD0a2QF06tRp3bp1a9euJZFIQpd35MgRDMNGjx7NaUMRurq6W7duFXDtoUOHUlJSRowY4eXlJSIz2tzcTCKRkIsFcrcQgJycnKenJ/yzkaFPnz5lZWXa2tqLFi0ikUjp6emJiYmrVq1KTU09f/48AKAlKRUVFR2BqKqqsst07txZTsDMpmB++QU0NIBOhydPWtx0FBcHAGBnx52OnA2+f+dOJ5P/fsFktlOVVCKbZhQN7SdMmODv7z9+/Hhzc3NJK2obZDJ54MCBenp6Yv5cFovl7e2NGq2FhcWIESO0tbW/fv0aGxu7Z8+ex48fx8bGco7iy8vLR4wY8enTJ2trawcHB3V19bdv38bGxq5fv76qqkroB7iyWKz4+HgAmPezISGVSqXT6Wpqajr/dHm+ffsWEBCgrKwcHh7eJvsueBCNxs7st2VlZR8/flRSUgIAtIolAHl5+cuXL7PfPnjwoKGhAV2LuH//vpub24ULF2bMmOHi4vLq1SvenzERoqgInp4QEQHBwTBmDPA+tJcv4cmTvzc4cfHbbwAAKSlAo/3dM0W8eAEAoKUFAqc78IdEnf9Fy+zZswHAzs6uublZ0lrwATreSl5e/uTJkyyOrSlFRUXDhg2bPXt2XV0dZ3nU09+0aRNn4fDwcABQVFSsEvb2lc+fP6Mv7ZcvXwSXRMKmT5+O3rJYLOTEvnPnTpTi4+MDAPv27UNvMzIyli9fPmvWrIkTJw4fPrx///7dunXT4mz/rUNeXv7t27fz588HgGnTpnX8lqdOnQoA8+bN63hV7eHLF0xTEwPAVq/GGhv/lfXxI9ajBwaALVjwv5SwMOzaNQzDMBYLs7LCALAlS/63x6m0FLOwwAAwX18x3oM4kM3eKOLo0aOPHj16/vz5sWPHVqxYIWk5AAA0Gi0qKurRo0dFRUX19fVGRkaOjo7e3t4teYZ/+vTp5MmT79+/r6ysJJPJTk5OixcvFpEbeU1NTWBgIADs2LFj4cKFnFldunRJSEjg7Qrt3bt3wIABs2fP5uzfzZ07d8mSJY2NjTk5OUOGDBGiwsrKSraeNl14+vTpuLg4CwuLlkIuFBYWhoaG8s0SPIjmHEHr6OgYGhrKy8sPGDAAAF6/ft0mkXzp16/f1atXv/OOjsWDiQlERcG0aXDoENy9Cx4e0KsX0Onw6hVcuwZMJowYAYcO/V04ORmWLIGBA+GPP4BEgmPHwMUFwsIgLQ1Gj4aaGrh0CUpLoXt3aHkNEK9I2o6LFrQaq6OjU1NTI2kt2O3bt/laQD09vXv37nEVZrFYe/bsYZsnthOPkZGRiOIGXLx4EQA0NTUZDEZH6ikoKEBSv3792tZrm5qaKisr8/LyUlJS4uPjr1+/HhERceDAgS1btty4cSMpKQnV3NTUJLgeKpVaVFRUXV2NYdiPHz90dHRIJFJCQgK7AFdvtKCg4OjRo+fPn799+3ZSUlJGRkZ+fj6VSm2rfkRWVhb6xz158qR9NbBB0RU8PT07WE+HePsWc3LCSCQM4H9/ZDIWEIBxjk5u3sR+/RXz8vpfyoMHWK9e/7tETg6bOBErKhL/HYgaGTejGIbt3LkzIyND0iqwhw8fovVrBweHhISEuro6FouVlZW1fPlyOTk5MzOz+vp6zvJRUVEAoK2tff78eTSUTk9PR92cAQMGsPgGg+gYy5cvB4Bx48YJLlZbWzt16tSpU6cWFxfz5jY3N6OJSwcHB/S2JbPIO4jW1NQU8Hs/Z86cd2hvDACyj61kypQpAODt7c2ZyGVGhc6YMWMAoH///q2c2WCxWOHh4VzfATqd3rNnTwAICwsTjcy2UFyMxcRgkZFYVBT27Bn3GL8lWCwsLQ27dQuLjcUKC0UsUWLImhn9/PlzTEzM2bNnY2JifjqDhmFYQ0NDcnLy9+/fRaqqoaGhW7duAODq6srbk7p27dqPHz+4Es+ePduzZ8/Hjx9zJn748AF1c96+fSt0kW5ubgDg5+cnuBjbfyA7O5ud+O7dO+Rs1K9fPwCwt7cvLS3FMKyioqJtgyMAHR0dExMTa2trR0dHd3d3b2/vVatWBQQE3L59m0KhoHXn58+ft/KmUBgqBQWFy5cvx3Hg4uICAAsWLIiLiyspKWn3Q2uJL1++oNUtc3Pzy5cvI7tfUVERFxfn5eW1bds2DMMaGxtVVFRUVFTS09PRztF+/fpduXKloqKCTqcnJib++uuvAGBhYVFbWyt0hUKjsRHbuxf7/FnSOiSJ7JjR6Oho3uj3v/3227t37/iWp9FoISEh3bt3BwA1NTWRart69SoAKCsrt6nF8l0ZQ9OCFy9eFJa26urqr1+/Njc3Ozk5AQBq4QKoq6tbs2bNmjVrOMO+cW55NDAwuHnzJkpvbGzkNYt+fn47duwICQk5e/bsrVu3Hj9+/O7du2/fvqHDUAWD/sVbtmxp5d258YYm4uHKlSutrK1NZGZm9unTh/0pnEvwQ4cOxTCsoaEBvU1LSyssLBw+fDivtoEDB7amNyBJtm/HALDhw7H/8EKujCwx7dmzZ8uWLQDQp0+fSZMmde7cuaqq6s6dO0+fPrW3t09ISOBc6ygpKQkKCjp9+jQKRikGEhISAMDZ2VlwbPO6urqMjAwAGDx4MIlE4uvxh1qjAGdAvg46XH45bMrLy5FfTmFhIQqfwfyZQ5+KisqBAwe4EmfPnj1y5Mjy8vL09PSQkJDJkyevWLHiyJEjCgoKVbxR0zvArFmzNm7ceOLEieXLlwveI8QuP3ToUN70GzduvHnzBu2p/+WXX4SokE2/fv0yMzOjo6MfPHiQm5tLp9PJZHLv3r1HjRo1btw4AFBQUHjy5AkAmJubq6urJyUlJSQkxMTE5OTk1NbW9uzZc/z48VOmTJHGWM6crFoFkZGQnAzHjoF0LORKAEnbcSHw4MEDNNTdunUr55AZrdI4OztzzU/l5eWpqqqOGjUqJCTk5cuXIPreqKIjSYEAAB18SURBVJ2dHQAEBAQILoZsKABw+RWxqa6uRgY0IyMD+Xi6ubk5OjpaW1ubmJjotGtbCJlM7tmz5+fPn5F/2MyZMzt4s/n5+Sic0suXLztYFS80Gs3ExAQArK2tc3NzObOoVOqFCxfQ63v37vn7+1+9erWlekQ9N/rf4s4dDABTU/vPDu2l+4eudezYsQPDMHd3d65IECQSafPmzZs2beJytzY1Na2srETuO+xlZZGCemQ/7T2hML3oBd8Cf/75J4vFsrS07NevH4lEunr1KoPB4CrD10GHyy+HjYGBAbuzY21tff78ebQfvCN069Zt0KBBT548efTokXAdngBAU1MzOjraxcUlLS3NysrKycnJysqqubn58+fPT548YTAYvXv3trW1ffjwYUhIyPTp0z08PIQrQHT4+/tHR0fv379/woQJktbSRiZMgJkzISoK5s6FpCRBEaFkFNyb0fz8fNTyW3IJ5GuShLgbhEqlUviB0plM5sWLF1ksFgD8dKd5v379UEm+5OXl7dmzBwB27dqFbioyMlJJSYnMQfs6pIixY8euXr06Ly/v0aNHaJ603aB9kDQarSOVtMSAAQPS0tJQIJLY2NjY2FiU3rlzZx8fn65duwJA//79J02aNGjQIFEIEBGVlZWfPn1CUUfxR2goJCbCs2cQFgbLlklajdiRdHe4o1y/fh0ANDU1f7pVaf78+fb29uzVD0R+fj7wDOpLS0vfvXv35MmTmJiYc+fOHTlyJCAgYNWqVd7e3u7u7mgQbWpqirwRBT9eEonU1NRka2sLAPv372/3bVZVVQ0cOBBEvKEF9YPMzc15PQcwDEMTJiwWq7KysrKysrm5+ePHjzNnzuRaRy4vL0fbWNlDbBHR1NSUnZ2dnJz84sWL/Pz8Nl3LYDCqqqpamjyRCBs2bACAoKAgSQtpL7dv/2eH9rjvjRYXFwOAqanpT0MwvHv3LiUlZcaMGT+tc+PGjWfOnGmlAG1tbTI/2OkAYG5u/ubNm/fv37eyTi6qq6tHjx797t27KVOmnDx5sn2VtIYTJ06kpKR8/vzZxsZmw4YNo0ePNjAwKCgoSEtLO336tL29/b59+2g0GrKS2dnZAQEBV65cSU9P37Vr15AhQ+Tk5DIyMjZs2FBZWdm9e3fksCk65OXlLSwsLCwsflry7NmzaWlpvr6+7DMR1NTUBIclFT+4ODlGEBMnwowZcOkSLFgAjx7x2YMvu+DejKLV9tYcEbF69eqSkpLfUNAEgZiamg4YMKAl+8i2kjo6OmQyuTVxLuzs7C5dunT//v3GxkbesOeCyc7OnjRpUk5OzoQJEy5duiTSdduuXbs+e/Zs1qxZz58/542MxbsF6/Tp0woKChcvXuTyK7KwsLh586ZY42gI5O7du9evXx8+fLg0Hy0jDdERO8rRo/DoETx+DCdOwJIlklYjPnBvRpEBZUdpE8D06dNbWeeWLVuQ+5Sw8PT0XLduXXl5+cGDBwUExOTl3r17Xl5eFApl7dq1QUFBYoidampq+uzZs6SkpIcPH3779o3BYGhqalpZWY0ePRp5g2tqaubm5gJA9+7dFRUVo6KiVq5ceevWrby8PDqd3qVLFycnJzc3N/bpQ9IALiwULkT+BD09OHkSXF1h/XoYMwZ69ZK0IHEh6VmFjnLp0iUA0NPTa9/lfOdGRQGKGicnJxcUFNTQ0MBOr6urO3/+fEpKCoZhBQUFc+bMmTNnTkNDQ2Nj4/bt2+Xk5FRUVM6ePStqebINOik2ODhY0kIEce/ePQAYO3aspIV0GE9PDABzdOR/fr0sgnszmo3ibwN8/PixHZeLzYw2NTUtXrwYSdXT05swYcKsWbN+//13FI1t9uzZ2L/9RpGHNgAYGhr+ysPGjRtFLbiVzJw509DQMDk5WdJCBLFr1y5oy94niYAcTtAGJ3xTUYEZGmIA2IkTkpYiJnA/qDc3N7e0tPz06dPx48ePHTsmaTktIi8vHxYWNmnSpMOHDyclJf31118o3djYeOrUqSiOn56e3pIlSwBAQUGhpKQEeS81NDR8+fKFq7aysjLxym8ROp1eWlrajr3z4gQX42VciGwVaGjv5gZr14Kzs0yeqMwF7s0oiUTasGHD3Llzw8PDHR0deVeHaTQa6vHl5eXV1tYaGxu3dDSjGHBxcXFxcWlsbKyoqKirq9PT0+M8aqJLly7Hjx9Hr9+ik3CkHlw0fkKkuHF1BQ8PuHYNFiyA+HiZX7XHvRkFgDlz5jx48ODy5cseHh5Tp079448/TExMqFRqVlbW5cuXKyoqPn36BACenp4pKSnHjx9fsmRJZmZmVlYW/BMJuLm5+dq1a6i2KVOmtP/4mtahqKjYmnN0t23b9v79+/3795uZmYlUT0fARePHhUg0+Kiurpa0ECERFlb7+vXO5maziIj5CxZIWo1okQUzCgAXLlywsLA4cODAlStXrly5wpllbW1NoVDI7LO0AADg4sWLnEGJmEwmOq0BAOrr65UFn80tLh4/fpycnLxy5UppNqOoNy3lFgoXZlRZWVlFRaW+vr6+vl6q/Bzaib7+gwMH9nl4aKWlOY8Zg0KpySoyYkbl5eV37NixYsWKuLi4Dx8+lJeXa2pqmpqa2tnZseP3PH/+nMViIbdNd3d30xambKQnoA4uGj8SKeVO47h4kgBAJpNLSkooFErnzp0lrUUIuP/xxx9//HH9+vV58+bFxcWJ4qRYKUFaTIZQ0NXVnTZtGm96eXl5UVER2kwJAElJSX5+fjt37pTyGBC4aPyESCEiY2YUAE6cOIECAEZGRqKT/mSS/0QsluDgYBsbG/Yo/vHjx2lpaQ8fPpSsqp+Ci8ZPiBQieNHZevT19UNCQgBgzZo1yLlQJpF9M1pRUXHixAkMw0aOHIlS1q1bFx0djaIlSTO4aFS4EKmhoaGoqEin0xsbGyWtRRC4eJhtZfr06VOmTKHRaD4+PhiGSVqOSJB9MxocHEyn0znDpqmqqrq5uQk+QE0awEWsCrysL+PiYcqkGQWAEydOdOrUKT4+vvURf/CFjJvRysrKEydOAIBw98iLB1w0KlyIBJzoxIXIdtCpU6fDhw8DwOrVq8UTKF3MyLgZPXDgQE1NzYQJE1DET3yBi0aFC5GAE524ENk+vLy8Jk+eTKVSFy1aJGktwkeWzWhlZSXaFLR161ZJa2kPuGhUWlpa8vLyNBqtublZ0loEgYvJB1zMPLSb48eP6+rq3rt37+zZs5LWImRk2YwePHiwpqZm/PjxgwcPlrSW9oALM0oikbS0tDAME9GRIcICFw8TFyLbTefOndGqvZ+fX2FhoaTlCBOZNaNVVVUoUsm2bdskraWd4KVR4UInIVIamDVrlru7u+wN7WXWjB46dKimpmbs2LE47YoCfhoVLnQSIqUENLS/e/fu+fPnJa1FaMimGaVQKGhW1N/fX9Ja2o+2tjaJRKJSqQKOC5UGcNH4cTHtiIsn2UGMjIwOHToEAKtWrZLyf0frkanNoGwOHTpEoVDGjBljb28vaS3tR0FBQUNDo6ampqamhjOenrSBi8ZPiJQe5syZk5yc7ObmJs3f6jYhg2aUSqWGhoYCPn1FuSCTyTU1NRQKRZq/cLho/IRIqSIiIuLgwYNPnjzx8fHp06cP3wLZ2dkeHh58J+VYLNZff/2VkJAwdOhQ9hlrERER6JQwvlhbW/MNuCEUZNCMoq6os7Nzaw4BlXLIZHJBQQGFQunRo4ektbQILho/LkTiwitLWJw5c+bDhw8ODg58zei1a9cePnxoYWHBZUaZTOaVK1f27dv38eNHAHj27BnbjF65ciU+Pr6lj5s1axZhRluLLHVFASeNn5h2FBayFnJU2Ny9e3fOnDmVlZXKysr9+/fPzMzkzA0LC+Prdbd8+fIXL16IdKlZ1sxoSEhIdXX1qFGjhg8fLmktQgAXjZ8QKURkL1aeEDE1NR07dqyrq6uLi8vz58/HjBnDmWtubs57ydevX1+/fq2jozN37lzRCZMpM0qj0Y4cOQK43bbECy4aPyFSiBBmVACWlpYXLlxo0yUHDx5sbm5evHixhoaGiFSBjJlR1BV1cnL6/fffJa1FOOCi8RMihQhedIqTsrIyFoulq6urpKTUpgurqqrOnTunpKS0bNkyEWlDyI7fKLsrit9tS7zgolHhQqS6urqSkhKDwWhoaJC0FkHg4mGKmV69ehkZGT19+rStF544cYJOp8+YMaM1J0h2BNnpjR49erSqqsrR0XHEiBGS1iI0iNUbIaKtrV1eXk6lUjt16iRpLS2Cl4cpLGbNmsX3BMmqqqoO1sxkMtEeHD8/vw5W9VNkxIzS6XTUFd2+fbuktQgTXDQqXIgEADKZXF5eTqFQCDMqPSgrK6upqfGmc3YdsrKyWCyWgYFBm2q+ePHijx8/nJ2dBwwY0FGVP0NGzOjRo0crKirs7e1lqSsKOGlUuBAJONGJC5FCJCIiYvz48bzpY8aMYZ+WZmxs3I6aUb9qzZo1HZHXSmRhbpTBYKAAXLt27ZK0FiGDi0aFl5CjuHiYuBAp/cTGxmZkZPTr12/06NFi+DhZMKNHjx4tLy+3s7NzdHSUtBYhg4tGRYQcFSIGBgaGhoaKioqSFoJvDh48CABr1qwhkUhi+DjcD+oZDAY65mXnzp2S1iJ8cNHyAYBMJldXV1MoFLSdUTrBxcP09vb29vZu61UYhgm2FxiGlZeXy8vL6+npdUAdPsjMzExISDA0NPT09BTPJ+K+N3rs2DHUFWWfnyxL4KLlA050Sq3Irl27amhovH//nm+ura2thoZGXFwcbxaLxYqOjh4+fLiamtry5cv5Xp6cnDxx4kR1dXVDQ0N9fX0tLa3Zs2fn5eUJ8wZETGBg4Pbt279+/drK8sHBwRiGrVixQmwbavHdG2UwGCh2YUBAgKS1iAQymcwOOSonJ72/eVJroTiRWu8xOp3OYDBamlmura1lMBhNTU2cifX19VevXt27d29WVhZK4XviZmBg4JYtWzAM69Gjh42NDYvFys7OvnXr1r59+4R+F6Jj7969dDp9xIgRJiYm+/fvT0lJAYDS0lIA+PLly9SpUwHA0NAQBdMoKiq6cuWKmpqar6+v2BTi24yGhYWVlZUNGzZs1KhRktYiEuTl5YmQo8LC1dXVxMTkl19+kbQQIRAcHLxt27bu3bsvW7aMxWKFhYXxlomOjvb391dUVAwLC/Px8WGP+n/8+CFqd3ThMnbs2NraWn19fQB4/vx5TEwMO6u6uvratWsAYGpqiszo0aNHGxoaFixYIM7pCxybUQaDceDAAQDYsWOHpLWIECLkaEcICAhobm5etWqVjo5Ov379+vXrx5mLYirOnz+/e/fuvNc2NTXdvHnz3bt3Y8aM4XWkS01NvXnz5vfv39XV1U1NTSdMmGBlZSXCO/k3CxcuHD9+vI2NDQCcPn2atwCLxUK+PgEBAfPnz+fMkhIb+vTp06amppa+1deuXWtoaNDU1ASAq1evstOjoqIaGxt5y7PHalu2bNm4caO6uroIJLcMhluCg4MBYOjQoZIWIlr69+8PAO/evZO0EEGsWrUKAA4dOiRpIdzIy8sDQF5eHt9cZD2TkpK40mk0WkhICDvGq5eXF2dubW0tO8YlGzk5uY0bN7ZPJDIlLf2LkXW+d+9eS5dHRkYCgKurK2fikydPAEBdXb2mpqZ9qghaj/ROtwmmvr4ezYrK2LYlXqS2o8eJiYnJr7/+ioZdeCciIqJr165+fn5lZWWmpqa8BWbMmHH58mVnZ+f4+PiCgoLMzMzNmzdjGBYUFHT58mXRCWMymdu3b9++fXtlZeVPCz979gwA7OzsUGSjpqYmKXdHwzV4HdTn5OQoKSkNGTLExcVF0lpEi9SaUSQJnbu3fPlyrpViGo3GYrE0NTVRf5CXxsZGOp3ekoMUlUotKCioq6szNTUVs4+OoaGhu7u7q6vrmDFjIiIiVq5cySWMQqGMHDny3r176Na6du26Z8+e0tLSyMjIixcv8nZUW0liYiLfxeiamhr0or6+Hnn1eXl5/fSZfPr0CQD69Olz9+7dgwcPJicnoxG0h4dHYGCgNG+HxSN4NaO//PJLTk5OSUmJpIWIHOk0o/X19cgClpaW8t3sbGJiUlVVlZqaam1tzZVFoVBOnToVGhpaWFi4atUqNKpgk5KSsm3btgcPHqDzUEkkkqOj47FjxywtLUV2N/9i4sSJEydObClXW1s7MTGxtraW6+cByevIvwlNjAhAUVER7ZtsTehMpOTmzZuhoaG6urpOTk61tbWpqakREREPHz588+ZNW7eoEwhAfGbU1taWyWTeuXOH77FC48ePLygoiIyMtLW15cqqqKjYt28f+7fa1NTUyclpw4YNurq6fFcGZAzpNKPt4+vXrydPnjx58iT7dmprazkL/PXXXx4eHvX19TY2NnZ2dnV1dffu3Xv06JG9vX1KSgrfIbZQwP7ZgqWlpdWafS+80TTQILojUTBWr17Nd/HnwIEDyLlHTU3tr7/+amVt9fX1AFBTUxMZGTl79mwFBQUA+P79u7Ozc05OzubNmyMiItotlYAbsc3ConBYWVlZfHNRC3n06BFX+rdv37p27QoAOjo6zs7Ozs7OyKz06NGjoKBA9Kolz+fPn5OTk3/8+CFpIf+irq4OfX9KS0v5FtDV1QWA1NRUzkQ/Pz95eXkHB4fDhw8vXboUAHx9fdm5DAbDyMiIRCKdPHmSnVhZWYk6erNmzWqHzlYuMRUWFqLbKSoq4iyAwltwLTFxwWAw0FjbwMDg69ev7RApiiUmNzc3AFi7di1XYbTqjTbvEggLaR/U+/v7FxYWDh48+MGDB8iAVlVVOTs7v3371t/f/9y5c5IWKHzodDqajztx4oSSkpKZmZmZmRlngUWLFjU2Nu7du5d3XEaj0c6fP5+QkFBeXq6np+fg4ODj46OlpSU+9QLx9/ffsmULmtcLDAzkylVTU7t169br168XLlzITtTV1V2/fr23t/eDBw/a/bkODg6oO8ZFcXFxu+sEgLFjx+bl5X3//r2hocHFxeXYsWM9e/bsSIVCBHVs2T8PbJDbLI1Go1AoqEERdBxpN6OPHz8GgJUrV7L/5bq6uqtWrZo5c+ajR48kqUxk1NfXI0/A0NBQvqcmnDlzpqGhYePGjVxmND093c3N7du3b+yU27dvHzp0KD4+vnfv3iJW3Sp+upQ/ePBg3hMc0QG85eXl7d7KxWQyuXYBITAMQy8MDQ2zs7PRizbVrKKioqmpWVlZ+ebNm5s3b65bt64d8kQBml5AC02cVFRUAICSkpL0/LjKANLu8ISaDVptYIPmB/gGzf7PQqVSXV1dv337Zmdn9/r1axqNlpaWNnLkyMLCQjc3N74ey+KhtLTUx8fHx8eHyWS2rwbU8nV0dNq9HfbFixfF/GAHslRQULCwsLCwsGjJr4Av9+/fz8jIqKioiI+P19TUXL9+PdoPIg1MmDBBTk4uIyMDbZ1kg2YA7O3tpXlvMe6Qut5ofX39lStXAOCPP/5QV1cfPHhwQUHB7t27hwwZwj5AFc3vTJo0SZJCpYzz589///69S5cu9+/fRx2NgQMH3r59u0+fPllZWf/3f/83a9YsUXzu6dOn+S4coyUOAKBQKKhzHRIS0r5fvoSEBACwt7fvgEzRMnLkyIMHD06ZMiUoKEh0wdlqamp69eoFAC9fvjQ1NWUHeEXLdA0NDdXV1QCgoKCgqalpbGw8Z86cM2fOeHh4REREjBgxgkqlBgcHnz17lkQibdy4URQK/7OI24zm5OTw7ZWwDxqjUqnoRGlHR0d1dfWdO3fGx8dnZ2dbW1t7e3vPnTv3wYMH165dGz58uExGxms3aPZj+vTpnIM1NTW1mTNn7t27Nzo6WkRmdNOmTYILkMlkFCSircc6IkpKSlAHavHixe24XGygfZmVlZWlpaUiOhuZxWKVl5cDAJqgcHJyevv2LTv3/v37aFnv999/R1uYQkJCsrOznz9/zhlxQkFB4cCBA87OzqJQ+J9F3Gb0p11IBQUFtDKLItdaWVk9ePBg+PDhDAbj2LFjx44dA4ABAwbcu3dPpAdP44L6+vovX74AgJWVFdrZwrvohHaRp6WliUjDyZMn+c6yLViwgE6nA4ChoWF4eHj7KmexWDNnzqypqZk4ceLYsWM7JFR4VFZWampqcv0qoJkHAGjHbm53d3cGg9HSgo+Li0vfvn2NjIzU1dXv3r0LAMh3ZdSoUXw9wNgOtlpaWk+ePLlw4cLt27e/ffumoaFhbW09f/582QjOIlWI24xOnz6d79fl4sWLyHFPT0/v48eP7PR3795NnjyZRCIFBgYymcyLFy/m5uamp6cPHDgwJiamb9++4pMufbx//x652bJYLDTNx/noEMhLl3fFVli4ubnxdeRG/kwdgcVizZs3LyEhoX///mfOnOlgbYKh0+noF3rZsmWCf54rKiqcnJy6d+8eFRXF/iY3NjaisdHQoUNRNI02IfjuUCB3xLhx49ivg4KCflqzgoJC++JAE7QNsblWtcNvlMFgdOnSBQDOnTvHTkxKSho0aBAAdOnSRSbDLqCBGwAotQDKzcnJefPmDXrNYrGuX78OAIqKiomJieyq3r9/P2zYMFSmtrZWiCLb5zfKyZ49e+DffqOc1NfXe3l5AYCFhUVHfGbb5ze6cuVKDw8PDw+PgQMHAkD37t3R28DAQCqVamdnBwCdO3f29fUNCgpav3498iVQUVF59uxZu6US4BepW2LiJDo6uri42MzMjHNeb/jw4Y8ePTI3Ny8uLr5169bMmTMlqFCk9O/fn+9yakpKCoZhAGBjY8NgMACARCJNnjx54sSJd+7cGTly5LBhw4yNjfPy8lJTU5GTJolEat/UpEQoKyubPHnys2fPBg4ceOfOHRFNNXKioqLi5OQE/7h/xMbGIv8nRH5+fn5+PgAwGIxNmzbFx8fv3r07LCzs5MmT7DJDhgw5cuTIkCFDRC2VQAqRajOKdn+amJhwLX1qamr279+/tLQUfblllaSkJL5HeCsrK6MVOTk5OXYBEol048aNPXv2hIeHo42JRkZGmzdvtrKy8vLyQod3ilM8J0htK+348+fPp0+fnp+fP3369IiICL5PoPV8+/YNwzA0puHl5cuXTU1NhoaGSkpKyB8AERcXx9dFDIlRVVXds2fPjh070tPTf/z4oaqqamFh8V/Yl0zQElJtRpEv9IcPHxobGznPSmxqakJ+xWiunQChqKi4Y8eOHTt2lJWVYRiGnh6Kyiq2uB68ZGdnozEvjUbT1NTMyMhAFgrtICovL0fLzTo6OiYmJsHBwf7+/k1NTdOnT1+zZg2X97iZmVlbY1cL/oa0FMC4W7duP61ZUVERTS4REEjd3GhVVdWQIUOGDBlSUlJSXFyM1j0XLlzIYDBQSSaTiWKyaWtrUygUsekXG+y5UfYtc4G6dTk5Oa2pzd3dHQDWrFkjVI1tmBtlHxZEo9EwDGN7vHMxderUp0+fCv6u3r17V7h3QUAgFKSuN9rQ0PDq1SsAYDKZ3bt3j4iImD179qlTp27dumVjY6OoqJiamlpUVKSqqnr58mVpPldDGsjOzkYxgYTuNKqgoODn5wf8Yh0hFi9ezGAwDAwM9PX13717B/94Ai1ZsoRv/OBffvnF2Nh4w4YNAj4UOZ8TEEgdYjPYw4YNs7GxQXNVvLi6utrY2Lx586a2tvbo0aNHjx5lr8JnZmb6+PiYmJgoKCgoKSmZmJj4+vrm5uaKTbmYaX1vND8/f9myZcuWLUPpVCq1ubmZXSwrKwuNpmfMmCEO3QQE/1VI2D/RGQikhIqKChScnMFgCFhiysnJoVKpbL9REok0fvz4zMzMIUOGaGtr5+bmPnv2rKmpyc7O7t69e0S3nYBAdEjdoJ6g9ejr68+ePRsASCQSk8ns3bv38+fPkQMpAPTu3Xv+/PkrVqzAkasTAQEeIXqj0gj6pwiIcIFhWEu5JSUlFArFwMAALfIQEBCIGsKMEhAQEHQIIuYgAQEBQYcgzCgBAQFBhyDMKAEBAUGHIMwoAQEBQYcgzCgBAQFBh/h/GVehCVkuhKYAAAFPelRYdHJka2l0UEtMIHJka2l0IDIwMjEuMDMuNQAAeJw9z7FLw0AUBvB3uUuaJmlyAatBETpJwEUHcbCagIODINg/wNFBpBaclQQEQeguDqKTUxc7dfASh4J0q4I6WBdxEhEcHcS7k9yDj/sdfBzvvljnFfg4PAj+x+ehPAkywgt+YhRw1bhIoBXABUgB3ZTQAgOFoXgOBSUlU6msZCnZSo5SRclV8pSokm+LxQ2AEiANkAmoDBoGzQLNBkwAO4ArQHQgLhAPdApjMFF8Ffzrz628+0GZuOwv/WaD29UbYaP5wxZn68vCLZJGruGtCM83avEG2pOu+km8dnglfY9P8uPHdiQ8Gh7lL5Rlwnb9OwPWl25O6/lb2pOdh4Vqtp72pbdbA3bKerLzjNvRXNaRptZO1E2GsnPQmIynkpH0++ZMfJddyo57fhY/hbvS438igUzFQUYljwAAAWl6VFh0TU9MIHJka2l0IDIwMjEuMDMuNQAAeJyVlN1qxiAMhs97Fd7AJL9qDsc6GIxtsIPdw853/8yq1JSNDz+xkLc2T41J3MIxPvfX759wDtq3LWAOmEKAf6eZhS8CgK1+/sBRCvNhQURBPRgQ6yqEp/DHmZ2N3WgUjFYSdQpILrcpfpKjQN2L4fAVtXUKT0rA6pGHL7LldYo4CkUFhe5LzLJOUUeR6kEjIqaMjvJxm5LcuUhkZOixIRRPeblNyRcKKqSeLSli65RyyXQx0m6p3EMxR6FYU2Q9ogrhZQrCpV600KCoMKxT8EJhUxnnorh+uuhqt2UGc6ewZlmn+NqFaCjUeYlTXqdca1cQuVMyg65T9EJRKyMiSnzHXlzt1g4ojKWfsxHdsZdZu9iuCTxF9qKcgto9MIU5cdTNENwa/RRHwqeY/5HWyadA9mICtLXqKVC9mCupxdPEW72zH/cm2kPHm+f3ffsFZJnmRcBjCEcAAAFselRYdFNNSUxFUyByZGtpdCAyMDIxLjAzLjUAAHicbZK7agMxEEV/JaUNWqF5STPaKrhJk0dvNuBAuhgbk3T++Iy07lbNiHuYp7jHQ4VldzxU7JF65B7F43vNy/GlQln2u/bKsm9PfkhaJT8krBJXaatKqypd6fJ0300UWQlzmFIEBkEO8wTRNIM1lrgUQ3SYPNEAITQoRlbCDDGlYuIIyHLxNIySJKETJOJEYWbPwWROCAuQNKIEpbf31mzayhgANUAs5CN7H9MiwXfBTLnPggRZGyEpvqZXAyNkL2oZ3HcURRVyJEwJOiITUmt1LADU71NDzg0Js2ZHGP0QQy9kNl9knjgSoB/Z5ipAJyApY++k/hlhHz6hpnD6vZw/bpdrTfF8+Xl29Xq6vv2dv75vESpsIVbcQqq0hVx5C6XKFuaaB9NLLQMqVQc0VxtQctcMMLvDBtjPHZwG6PbcYnO3DpKTW3uLizt9S/X+D48D4Yog0pAqAAAAAElFTkSuQmCC",
+      "image/svg+xml": [
+       "<?xml version='1.0' encoding='iso-8859-1'?>\n",
+       "<svg version='1.1' baseProfile='full'\n",
+       "              xmlns='http://www.w3.org/2000/svg'\n",
+       "                      xmlns:rdkit='http://www.rdkit.org/xml'\n",
+       "                      xmlns:xlink='http://www.w3.org/1999/xlink'\n",
+       "                  xml:space='preserve'\n",
+       "width='800px' height='300px' viewBox='0 0 800 300'>\n",
+       "<!-- END OF HEADER -->\n",
+       "<rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='800' height='300' x='0' y='0'> </rect>\n",
+       "<path d='M 93.5967,170.73 L 132.493,148.273' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 93.5967,170.73 L 54.7002,148.273' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 270.766,155.758 L 315.68,155.758' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 270.766,155.758 L 248.309,116.862' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 270.766,155.758 L 248.309,194.655' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 315.68,155.758 L 338.136,194.655' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 315.68,155.758 L 338.136,116.862' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 705.811,160.052 L 745.152,181.721' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 705.811,160.052 L 727.481,120.711' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 666.471,138.382 L 628.034,161.618' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 666.471,138.382 L 665.567,93.4778' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 628.034,161.618 L 588.694,139.948' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 628.034,161.618 L 628.938,206.522' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='93.5967' cy='170.73' rx='8.98274' ry='8.98274' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='132.493' cy='148.273' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='54.7002' cy='148.273' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='270.766' cy='155.758' rx='8.98274' ry='8.98274' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='315.68' cy='155.758' rx='8.98274' ry='8.98274' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='338.136' cy='194.655' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='338.136' cy='116.862' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='248.309' cy='116.862' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='248.309' cy='194.655' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='705.811' cy='160.052' rx='8.98274' ry='8.98274' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='745.152' cy='181.721' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='727.481' cy='120.711' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='666.471' cy='138.382' rx='8.98274' ry='8.98274' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='628.034' cy='161.618' rx='8.98274' ry='8.98274' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='588.694' cy='139.948' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='628.938' cy='206.522' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='665.567' cy='93.4778' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='684.142' cy='199.392' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-0' d='M 93.5967,170.73 L 126.005,152.019' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-1' d='M 93.5967,170.73 L 61.1884,152.019' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-2' d='M 270.766,155.758 L 315.68,155.758' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-2' d='M 277.503,146.776 L 308.943,146.776' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-5' d='M 270.766,155.758 L 252.631,124.348' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-6' d='M 270.766,155.758 L 252.631,187.169' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-3' d='M 315.68,155.758 L 333.815,187.169' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-4' d='M 315.68,155.758 L 333.815,124.348' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-7' d='M 705.811,160.052 L 738.664,178.147' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-8' d='M 705.811,160.052 L 723.357,128.197' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-9' d='M 705.811,160.052 L 666.471,138.382' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-14' d='M 705.811,160.052 L 688.265,191.907' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-10' d='M 666.471,138.382 L 628.034,161.618' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-10' d='M 665.352,149.555 L 638.447,165.82' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-13' d='M 666.471,138.382 L 665.717,100.963' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-11' d='M 628.034,161.618 L 595.182,143.522' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-12' d='M 628.034,161.618 L 628.787,199.037' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='127.502' y='150.518' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='59.6913' y='150.518' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='333.145' y='196.9' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='333.145' y='119.108' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='253.3' y='119.108' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='253.3' y='196.9' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='740.161' y='183.967' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='722.49' y='122.957' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='593.685' y='142.194' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='623.947' y='208.768' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='660.576' y='95.7235' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='689.133' y='201.638' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='93.5967' y='187.946' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>1</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='145.459' y='143.033' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>2</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='41.7348' y='143.033' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>3</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='255.795' y='158.004' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>4</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='308.194' y='170.969' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>5</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='351.102' y='204.386' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>8</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='325.171' y='111.622' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>9</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='235.344' y='111.622' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>6</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='261.274' y='204.386' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>7</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='720.191' y='158.132' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>1</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='758.265' y='191.19' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>2</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='714.367' y='115.734' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>3</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='679.283' y='132.883' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>4</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='627.733' y='148.895' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>5</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='575.58' y='134.971' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>8</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='642.052' y='215.991' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>9</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='652.453' y='88.5003' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>7</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='697.255' y='208.861' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>6</tspan></text>\n",
+       "<path d='M 91.4009,163.992 L 91.3976,163.915 L 91.3876,163.839 L 91.3711,163.763 L 91.3482,163.689 L 91.319,163.618 L 91.2837,163.549 L 91.2427,163.483 L 91.1962,163.422 L 91.1446,163.364 L 91.0882,163.311 L 91.0275,163.264 L 90.9629,163.221 L 90.8948,163.184 L 90.8239,163.154 L 90.7506,163.129 L 90.6755,163.111 L 90.5991,163.099 L 90.5219,163.094 L 90.4447,163.096 L 90.3678,163.104 L 90.292,163.119 L 90.2177,163.141 L 90.1455,163.168 L 90.076,163.202 L 90.0096,163.242 L 89.9469,163.287 L 89.8883,163.337 L 89.8342,163.392 L 89.7851,163.452 L 89.7413,163.516 L 89.7031,163.583 L 89.6709,163.653 L 89.6448,163.726 L 89.6251,163.801 L 89.6118,163.877 L 89.6052,163.954 L 89.6052,164.031 L 89.6118,164.108 L 89.6251,164.184 L 89.6448,164.259 L 89.6709,164.332 L 89.7031,164.402 L 89.7413,164.469 L 89.7851,164.533 L 89.8342,164.593 L 89.8883,164.648 L 89.9469,164.698 L 90.0096,164.743 L 90.076,164.783 L 90.1455,164.817 L 90.2177,164.844 L 90.292,164.866 L 90.3678,164.881 L 90.4447,164.889 L 90.5219,164.891 L 90.5991,164.886 L 90.6755,164.874 L 90.7506,164.856 L 90.8239,164.831 L 90.8948,164.801 L 90.9629,164.764 L 91.0275,164.721 L 91.0882,164.674 L 91.1446,164.621 L 91.1962,164.563 L 91.2427,164.502 L 91.2837,164.436 L 91.319,164.367 L 91.3482,164.296 L 91.3711,164.222 L 91.3876,164.146 L 91.3976,164.07 L 91.4009,163.992 L 90.5026,163.992 Z' style='fill:#000000;fill-rule:evenodd;fill-opacity=1;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;' />\n",
+       "<path d='M 97.589,163.992 L 97.5857,163.915 L 97.5757,163.839 L 97.5592,163.763 L 97.5363,163.689 L 97.5071,163.618 L 97.4719,163.549 L 97.4308,163.483 L 97.3843,163.422 L 97.3327,163.364 L 97.2763,163.311 L 97.2156,163.264 L 97.151,163.221 L 97.083,163.184 L 97.012,163.154 L 96.9387,163.129 L 96.8636,163.111 L 96.7872,163.099 L 96.71,163.094 L 96.6328,163.096 L 96.5559,163.104 L 96.4801,163.119 L 96.4058,163.141 L 96.3336,163.168 L 96.2641,163.202 L 96.1977,163.242 L 96.135,163.287 L 96.0764,163.337 L 96.0223,163.392 L 95.9732,163.452 L 95.9294,163.516 L 95.8912,163.583 L 95.859,163.653 L 95.8329,163.726 L 95.8132,163.801 L 95.7999,163.877 L 95.7933,163.954 L 95.7933,164.031 L 95.7999,164.108 L 95.8132,164.184 L 95.8329,164.259 L 95.859,164.332 L 95.8912,164.402 L 95.9294,164.469 L 95.9732,164.533 L 96.0223,164.593 L 96.0764,164.648 L 96.135,164.698 L 96.1977,164.743 L 96.2641,164.783 L 96.3336,164.817 L 96.4058,164.844 L 96.4801,164.866 L 96.5559,164.881 L 96.6328,164.889 L 96.71,164.891 L 96.7872,164.886 L 96.8636,164.874 L 96.9387,164.856 L 97.012,164.831 L 97.083,164.801 L 97.151,164.764 L 97.2156,164.721 L 97.2763,164.674 L 97.3327,164.621 L 97.3843,164.563 L 97.4308,164.502 L 97.4719,164.436 L 97.5071,164.367 L 97.5363,164.296 L 97.5592,164.222 L 97.5757,164.146 L 97.5857,164.07 L 97.589,163.992 L 96.6907,163.992 Z' style='fill:#000000;fill-rule:evenodd;fill-opacity=1;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;' />\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='190.401' y='153.6' style='font-size:24px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>+</tspan></text>\n",
+       "<path d='M 396.044,150 L 515.814,150' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 515.814,150 L 510.628,147.006' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 515.814,150 L 510.628,152.994' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "</svg>\n"
+      ],
       "text/plain": [
-       "<rdmc.mol.RDKitMol at 0x7fab24888a50>"
+       "<rdmc.reaction.Reaction at 0x7fdc05c1bd10>"
       ]
      },
-     "execution_count": 6,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[C:1]([H:2])[H:3].[C:4](=[C:5]([H:8])[H:9])([H:6])[H:7]>>[C:1]([H:2])([H:3])([C:4](=[C:5]([H:8])[H:9])[H:7])[H:6]\n"
+     ]
     }
    ],
    "source": [
-    "r_complex"
+    "rxn = Reaction(r_complex, p_complex)\n",
+    "display(rxn)\n",
+    "print(rxn.to_smiles())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72011132",
+   "metadata": {},
+   "source": [
+    "# [Method 2] Atommapping using RXNMapper (Beta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00c88598",
+   "metadata": {},
+   "source": [
+    "### Map heavy atoms using RXNMapper"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cf8b498",
+   "metadata": {},
+   "source": [
+    "Based on version 90a7012c9c0127f4a347baf815e270d8807b5a39\n",
+    "\n",
+    "[Developer TODO]\n",
+    "\n",
+    "- A deeper investigation in rxn_mapper is need in the future to check possibilities of built-in H mapping \n",
+    "- modularize the following cells"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
+   "id": "dce65ebe",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Some weights of the model checkpoint at /Users/xiaorui/Apps/mambaforge/envs/rmg_3.2/lib/python3.7/site-packages/rxnmapper/models/transformers/albert_heads_8_uspto_all_1310k were not used when initializing AlbertModel: ['predictions.dense.bias', 'predictions.bias', 'predictions.decoder.bias', 'predictions.LayerNorm.weight', 'predictions.LayerNorm.bias', 'predictions.decoder.weight', 'predictions.dense.weight']\n",
+      "- This IS expected if you are initializing AlbertModel from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing AlbertModel from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n"
+     ]
+    }
+   ],
+   "source": [
+    "rxn_mapper = RXNMapper()\n",
+    "r_complex_smi = \".\".join([rsmi[0] if isinstance(rsmi, tuple) else rsmi for rsmi in reactants])\n",
+    "p_complex_smi = \".\".join([psmi[0] if isinstance(psmi, tuple) else psmi for psmi in products])\n",
+    "rxns = [r_complex_smi + '>>' + p_complex_smi,]\n",
+    "atommapped_rxn_smi = rxn_mapper.get_attention_guided_atom_maps(rxns)[0]['mapped_rxn']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9d627a25",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcIAAACWCAIAAADCEh9HAAAABmJLR0QA/wD/AP+gvaeTAAAgAElEQVR4nO3deVhTx9oA8DchIezIpgKiiLK5gQgioiKC1g0RK1Vb3Kr1qlUqqFWrrbXXWq8bluuCeN2VWrwqat1RqOAGCmiVzbK4sYlsgQQSk/P9MTaXksWQkwT0e39Pnz7JzJyTl+TkzZwzc0YGRVGAEEJIVcy2DgAhhN5vmEYRQogWTKMIIUQLplGEEKIF0yhCCNGCaRQhhGjBNPoOv/zyi5eX15QpU+Q12LZtm5eX15IlS2TW8ni8TZs2+fj4WFhYGBgYdO3aderUqTdv3tRYvFBTU+Pl5eXl5ZWbmyuzQU5ODmlQW1srs4FAIDhy5IiPj09AQMDt27elG1AUdfTo0YCAAGtra2NjYxcXl/Dw8OfPn6sc87x581xdXTdu3Civwbhx41xdXQ8fPiyvQXJy8oQJE5ycnNauXSuzQXl5+XfffdejR4/hw4eXl5erHCrx22+/ubq6+vj4yGuwZ88eV1fXyZMny2vw4sWLFStWODg4BAQEcLlcBa8lFosnTJjQ4y8ikUi1mHv37u3q6pqSkiKztrS01NXV1dXVtaCgQGYDgUBw6NChAQMGDBgw4Ny5cy1qt2zZ0kOOsrIy1QJ+n1BIoW3btgGAq6urvAbh4eEAMGbMGOmq8vLyXr16kffZ2tq6V69e+vr6AMBgMDZv3qyhgCsqKsgr3rt3T2aD9PR00qCysrJFVW1t7fbt2+3s7CSHx7Fjx1q0efPmzccff0xqmUymoaEheWxiYpKSkqJazB999BEAfPXVV/IaODs7A0BUVFSLcoFAEB8fP2jQIEnA0h9EXl5eeHg4eeeJgoIC1eKUOHr0KACYm5vLa7B+/XoA8PDwkK7KzMycN2+enp6eJB7pD6K5Xbt2AYCk/Zs3b1SLmcFgAMCFCxdk1j59+pTs//Hjxy2qampqtm/f3qVLF0nA0h/E7NmzZaYXNputcsDvEeyNatDy5cuzs7NNTU2TkpJKSkoeP35cUVExd+5ciqJWrFjx8OHDtg7wb65evWpjY7NkyZKSkpLhw4cbGRnJbLZhw4aTJ08ymcz169fX1dXV19dnZGT07du3rq4uJCSkurpaawELBAInJ6dPPvnkzp07bm5uHh4eMqN1cXGJjo7W19efOHGi1mKTZ+XKlf3794+NjTU2Ng4KCnpn+5KSkm+++QYAyP+1Ly0tjRwV5eXlI0eO7Ny5s8xmpaWlALB58+aqv6uoqNDR0dFuyG0A06gGnT59GgAiIyOHDx9OSoyMjHbt2mVmZiYWixMSEtoyOClubm6jR48+dOhQeXl5UlKSubm5dJuamppNmzYBQERExOrVq0lXtH///hcvXjQ1Na2srIyKitJawLq6ujNmzNi+fXtRUVFWVtaYMWOk2/j5+YWHh1+7dq28vJx069rWiBEjli1bduPGjdLSUvJOKrZw4cKamprPPvts5MiRWghPWr9+/UJDQ+Pi4ioqKq5cudL8TKW5kpISAOjRo4fZ33Xo0EG78bYNVlsH8MF68+ZNfX09ALQ48thstp2dXXV1tbxLk22lY8eO//3vfxW3OXv2bH19PZvNXrlyZfNyW1vbWbNm/fzzz7/88ssPP/ygyTD/Zt26dYob+Pr6+vr6aicYZYwaNWrUqFFKNj5+/PiZM2dMTU03b94sOenWMj09vYMHD76zGUmjNjY2Gg+oXcLeqKawWCxyOSkhIYFqtnBBXV0duYrv7u7eZsGp6saNGwDg5eVlaWnZomr06NEA8Oeff5JvFKKpqqqKjFtu2rTJ2tq6rcNRRCAQvH79GgDaeZyag2lUnTZu3GhhYTFgwADydM6cOQBw9uzZSZMmZWdnk8KVK1c2NDT0799fwei/1hQWFlpYWFhYWKSlpSnTnoz+29vbS1d1796dPMjJyVFfgDIMGzaMw+EsXrxYo6+iRjExMRwOx8LColVbRUZGlpeXe3t7z507V0OByVNXV8fhcDgcztmzZ5VpX15eTlEUg8EQCAT79+///vvv169ff+bMmaamJk2H2k7gSb1SXr58+dlnn8msun//vuQxj8erqqoyNTUlT1evXp2fnx8XF5eQkJCQkDBw4EBra+szZ86MHj36yJEjurq6Go15zZo1Mq9vVlVVSR6LRCLyVCgUKrPPyspKAOjYsaN0lZWVVfM2Kjh37lxRUZHMqpcvX0oeCwQCgUCgZMAaxeVyg4ODZVY9efJE8lgkEgkEglbllOvXrx8+fJjFYu3Zs4fJVGdf54cffoiJiZEu5/P5kscURQkEAgBQcnKV5PzD0dGxebm1tfX+/fvJacqHDdOoUurq6uLi4t7ZbPTo0aamppLL6iwWKyQkJCEhgXyFSI+PwWA4OTmp97sh06VLl97ZxsrKasuWLdCsL6kYj8cDADMzM+kqMzMzJpMpFosbGhpaGelbhYWFhYWF72y2atWq5jPJ2pBQKFSmv+bv779nzx42m63kbnk83rx58yiKWr58uZubG70YW7pz58472xgYGOzZswcA+vfvr8w+7e3tZ8yYUVpaOnbs2J49ezIYjMePH0dHR798+TI4ODg5OVnBBNsPA6ZRpXTr1u3AgQMyq3bs2HHq1CnyePDgwYMHD5ZUbdiwYfXq1VZWVpcuXXJ0dIyPjz98+PD9+/ejo6PPnz9/+fLlHj16aC7mmJgYJycn6fL8/Pz58+eTxx06dFi6dKny+ySzF2VOF+dyuWKxGACaz9BslalTp0ZGRsqsCg0NlYyxyOsAap+pqenVq1dlVh04cGD37t3kca9evVqV9NesWVNQUNCtW7fVq1erIcq/+/nnn2UmtfLycskELDabPW/ePOX32alTp0OHDjUvGTdu3IIFC4YNG5aVlbVixQpySf0DhmlUKQYGBv7+/jKr5M1bysrKWrNmDQDExcUNHToUAMLDw8PDw69fvz516tSCgoIvvvji+vXrmovZ09NTcpW2OWNjY5X3STrar169kq6SFMrsqyqjU6dOXl5eMquaT1ZvP3R0dOQFfOXKFdX2mZ6eHh0dDQA7duyQ3NqgRo6OjjJjfvbsmXpfyNjYeMWKFdOmTUtJSamurlb5qHgv4BCTphw/fpyiKGdn58DAwOblI0aMIOfRSUlJZHzzPULuJmp+pVJCUkjaINV8+eWXIpGIzWZ///33ns1IbhMaOHCgp6cnuXbZzklOhmQeMB8S7I1qCrmvQ+ZojIuLi6RNawdw25a3t/fRo0fv3LnT2NjYooeYnJwMANbW1jLH8ZGSSK9QKBQ2H7psLiMjAwDI9ZN2TtLDlfkt+JBgb1RTyFTkR48eNTY2tqgi3wQmkynvnpB2KyQkhMVi1dfXt7hSzOfz9+3bBwCTJ08m924j1dy9e7dAlpMnT5IG+fn5BQUFHA6nbeNsjsfjybxGTFYwcXBwkMzi+FBhGlWn/fv3Dxs2bOrUqQAQGhrKZDKrq6vnzZtHBriJnJyc7777DgCCg4MlU6PayosXL4YNGzZs2LBHjx4p057crQQAX3/9dVJSEink8XgzZ8589uyZnp7esmXLNBctMWvWLA8Pjw0bNmj6hdQlPj7ew8NjyJAhyjTu1q2bgyySG4TIU43+VtXX13t4eHh4eEg+YgUEAkFISMjo0aMjIiLIGRgA8Hi8b775hvzWrlq16oP/ZcU0qk7FxcUpKSlkYpOHhwcZYjpy5EjPnj0/++yziIiIoKAgNze3V69e2dvb79ixo63jBT6fn5KSkpKSQu5MXb9+vWR9MzIZMCIigjyVrAS4ZcuWvn371tfXjxgxwsPDY+TIkXZ2didOnGAwGHv37u3ataumY87Nzc3MzCQnjA8ePDD/y9atWwEgMTFRUvLmzRsA+Oijj8hTV1dXsgcPDw9SQqb1aNqrV68yMzOzsrLIUx8fH/Lq3t7epKRnz56k5JdfftFCPO8kEokyMzMzMzNramoAYPv27ZK3NDMzEwBWr15Nnk6cOJHNZnt6elIURVaBcnFxcXd3t7S0/OmnnyiKWrJkifZvH9A+vDaqTh4eHrNnz5acwqxbt87Nze1f//pXWlqaZNqpubn5tGnTfvjhB5lz47XM1NSUjF106tQJAF6/ft1i5mZFRQVZeU+y/p6pqWlqauqaNWuOHDlCvlQA4O3t/eOPPwYEBKgWhq6urq6uLosl92hs3mDKlCne3t7kTvk3b960WFNKKBS2KOFyuS1KJKsZSF9vUZKOjo6urq6CM2sWi0ViBgA3N7fw8HBJ47q6uhbxkGwFABq97YfD4YjFYnkTlhkMBomWyWRyOByy/GPPnj0BgM/ntwiYx+ORE6z6+noGg/Hjjz9OnDhx8+bNly9fzsvLAwAdHZ3AwMDIyEiZ68V8eBgU/jv1ConFYpFIxGAw5H3JSQMmk6lgQbDq6urCwsKGhoaOHTv27NlTQb5QC3KHj7z53hRFkW6a8hPC5b3K8+fP6+vrbW1t36+BMqQhYrG4oqJCIBB06tSpXV291TQ8qX8HJpPJZrObJ76wsLARI0ZILgORBooXVTQzMxswYMCwYcNcXFw0nUMBgM1mN0+RBw8e9Pf3lywdz2AwWjRQ+VUcHBz69eun9hz64sULLy+vSZMmqXe3GjVnzpyBAwcqeYm5PTh58uTAgQOVWaxPeUwms3Pnzl27dv1/lUMBT+pVcOvWraKioub3ILdzRUVFycnJkjVP27/GxsZ79+5pcwVo+rKzs9PT0xX/cyDtSnl5eXp6uqenZ1sH8iHA3ihCCNGCaRQhhGjBNIoQQrRgGkUIIVowjSKEEC2YRhFCiBZMowghRAumUYQQogXTKEII0YJpFCGEaME0ihBCtGAaRQghWjCNIoQQLZhGEUKIFkyjCCFEC6ZRhBCiBdMoQgjRgmkUIYRowTSKEEK0YBpFCCFaMI0ihBAtmEYRQogWTKMIIUQLplGEEKIF0yhCCNGCaRQhhGjBNIoQQrRgGkUIIVowjSKEEC2YRhFCiBZMowghRAumUYQQogXTKEII0YJpFCGEaME0ihBCtGAaRQghWjCNIoQQLZhGW43JZDIYDAaD0daBKMvExMTa2trY2LitA1EWi8Wytrbu1KlTWweCkFIYFEW1dQwIvfeqq6uFQqG5uTmLxWrrWJTC5/O5XK6BgYGRkVFbx/Leo5VGL168mJKS0rNnz88//1xmg7i4uEePHnl5eYWEhEgKo6OjS0pKFOx26tSp7u7uKkelmgcPHly/fv358+c8Hq9jx44DBgwYNWqUvr6+4q3++OOPixcvOjk5TZw4UTtxEhRFpaenJycnl5SUNDU1dezYcfDgwf7+/rq6uvI2EYlEFy5cyMjIKCsrMzAw6N+//8SJE7X5FSovL79y5UpOTs7r16+NjIycnZ3Hjx9vY2OjYJOMjIxr1649e/YMABwdHYOCgrp3766teCE/P//q1atFRUVcLtfS0rJv375jx441MTFRZtv6+vq4uDjy2NXVdejQoZqM9H9adRjn5OSkpKTIrAoKCrK2ttZkpK3B40FyMqSlQWUlMBjQsSMMHgxDh4L8o/1vGhrgyhXIyIDKSujQAXr2hJAQMDdXZ4QUDUuXLgWAgIAAeQ0+/vhjAJgzZ07zwv79+ysO6dixY3Siaq2srKwhQ4ZIh9GpU6f4+Hh5W6WkpIwfP56c2uvp6Wkz4Bs3bsj8menevfvVq1dlbnLt2rWuXbu2aG9lZXX58mUtBMzlchcsWMBms1sEwGKxIiIiGhsbpTepqKgYM2ZMi/ZMJjMyMlIkEmk64IKCgnHjxkm/w6amprt371ZmD+Hh4ZKt5s+fr+mAKfmHcefOnU+cOCFzk59++knG1w8AAHJzc7UQ87uJxVR0NGVpSQG0/M/OjlImUezdS1lYtNxWX5+6f1+NYbbBCciaNWsqKyulyysqKr799lsAcHFx0VowKSkp48aN43K5urq6oaGhQ4YMMTU1ff78eXx8/P3796dMmSIUCj/99NPmm8TFxW3YsOHx48cAwGQyKe1eFUlISJgyZYpAIDA0NJw2bdrAgQMNDAyKi4uPHTuWk5MzduzY8+fPjxw5svkmiYmJY8eOFQqFPj4+YWFhNjY2BQUF27ZtKykpCQkJuXfvnqurq+YCrqurCwgIuHfvHgAMHjx44sSJtra2dXV1SUlJJ0+ejIqKKi4uPnXqVPNNamtrBw8e/Oeff3p4eMyYMcPe3r6qqurEiRMXL17ctm2bkZHRunXrNBfw48ePAwICysvLmUxmcHDwiBEjLC0tS0tLExISbty4sWDBAi6Xu3z5cgV7uHPnzo4dO/T09Pr373/79m3NhSqh+DD+5JNPjh492uIwBoDS0lIAGDZs2NixY1tU2dvbayHsd1uwAPbsAQAYMACmTAFHRxCJ4PFjOHYM8vPhs8+goAC+/Vbu5uvXv6319oZPPwV7e6ithfv34elTeFdnrnXo5GDVeqPykBzq7+9PJ6RWqaqqsrW1BYCuXbtmZ2c3rxKLxf/85z99fHxKSkpabLVgwQILC4vp06fHx8cnJCSAFnujxcXFpqamANCnT59nz541rxIKheHh4WPGjKmpqWmxlbe3NwAsXLiweT+upKSEnJ/OmjVLozHPnDkTAHR0dPbu3dui6vbt2w4ODtI94p9//hkAQkJCBAJB8/Lp06cDQIcOHYRCoYaibWpq6tOnDwCYm5vfunWrRe2+fft69+6dn5+vzB7Wr19PAtZ0b1SZw7i0tFR6w8mTJwPAxo0bNRqe6vbtowAoBoPatIkSi/9WJRBQ8+e/rb10SfbmN29STCYFQK1e3XJzdWsvabShocHS0hIAzp07RyekViEnNTo6Ounp6TIbvHnzRrqQy+VKyhMTE7WZRsmpooGBQWFhoXStWCyWecJbV1e3e/fupqamFuULFy4EAHt7e43ESlEURT158oTJZALAqlWrZDaQ+Q5TFHXhwoXKysoWhWfOnCG//dK/bepy5MgR8hJnz56V2UBewBLff/89ADg7Ozc2Nmonjap2GFMU5evrCwCHDh3SZHSqEggoGxsKgJo9W3YDsZgaNowCoPr3l91g9GgKgBoyRNM5lKKo9jLh6dChQ5WVlU5OTtLnF5pz7NgxABgzZoynp6fMBjo6OtKFRkZGMss1jaIoEnBYWJjMkRYGg0FyVgvGxsbz58+XHn1ydHQEAJkXWNQlLi5OLBZzOBx5Z8Hy3skxY8ZYWFi0KCwrKwMAFoslXaUu5B12d3cPCgqS2UDxR5+Xl7dx40YGg7F7924Oh6OREKUcPXoUWn8YAwAZ6VU8ytdmLl+GkhJgMOCbb2Q3YDBgzRoAgMxMyMpqWfvqFVy9CgCweDFofm6i9q6NxsbGXrt2zcXFRfrCllgsjo6OBoClS5fKTASaUFdXl52dDQAyBxNaOH/+/JUrVzp16vSNvA9V8548efL69WtQLuC4uLi7d+86OjouWrRIXhuSQM3MzNQYZAvkyqCvr+87X+Xly5ebNm0CgBUrVsj8Yjc2Nu7btw8AQkNDFUxIoIOiqLt374Jy73BqauqJEyd0dXU3b95MSsRi8dy5cxsbG+fMmePv76+JCKXV1tbm5OSAcjH/9ttvV69elRzG5GeJjMiXl5cDQDuaq5uaCgDg6Ag9e8ptM2IEGBgAjwc3b4K7OyQkQFIS2NrC119DejqIRMBgwIgRbxtXV4OODig30aK11JBGS0tLDxw4ILPq6dOnksdpaWnx8fG+vr7SafTs2bO5ublWVlbkJAgAKisreTwe/djk6dSpU1FRkVgsBoBevXq9s/3Nmzejo6OdnJyUSaNNTU3koFQjc3PzgoIC8liZgK9cuXLo0CE/Pz8FaZRMdvHx8QENxMxms62trQsLC0G5gCsqKshP6eeffy5Jo0Kh8OHDh69evcrOzt65c2dhYeHAgQP//e9/k1oyEUpdjIyMKIqqrq5WMuCHDx9GR0fr6+tL0ujOnTtTU1MtLCw2btwob6uXL1+KRCJ1xWxiYlJcXEwO4969e7+zffPDuKamhs/nA8CyZctu3rzJ5XIBwMzMbPr06d9//z352RMIBCTVqsCCyTQUi1XbFrp2hSdPAAAUD37q6ICLC2RkQH4+AMCNGxAdDX37wtdfQ3Y2AICFBYhEEBkJv/4KZJKljQ3MnQurVoGeHtmHWCxOTk7u378/nf6EGtJodna2vHmjzfXt23f06NEyP+ytW7cCwMKFCyUT3ObOnSu5EKYJycnJktuQlHn7bGxs3N3dlRy+vHPnzvDhw2lEJ8OuXbskcSoTcLdu3dzd3clpu0zp6ek3btwAgFmzZgHArVu3Rkh+t9XBwcGhoKCgtrYWlAvYwMCAzOJqPsmxqqqq+YnqyJEjExISDAwMAKCxsbFbt25qDJikD/JYmYCtrKzc3d0l0T579mz16tUAEBUVRa7yy+Tp6alyYpK2fPlySSe0tYdxQ0NDhw4dampqcnJyfH19ORxOXl5ebm5udHT02bNnb9++3blz54cPH3p5eakW2x9Dh/aRMyn13RoboaYGAKBDh3e0JNM/q6sBALp0AXd3cHICAKitBQB48wbc3KC8HCwswM0Nnj2DkhL44Qe4ehWSkoDDAYBdu3YtXrw4MDDwKrkIoBI1pFF7e/tp06bJrDp9+nRubi55/NVXX3311VfSbdLT01NTUzkczvz58yWFVlZWdnZ29GOTR09PTygUkseUEjOWFi1apKBbJ71ztQdvbGwsudyhTMDr1q1TMCuIx+PNnj0bAAICAsj0TLXHTHqUyt8y6+zsnJmZ2aLQ0NBwxYoVb968KS0tvXTp0tWrV11dXS9evNirVy8Gg6HegC0sLFr1DoeGhoaGhkqeLl68mMvl+vn5hYWFKdiqS5cu0vNnVWZmZtaqmBcvXrx48WLy2NbW9unTpy9evGje9b548eL06dOLi4sXLFhw+vRpDoej8ptMmZmByh8QgwHk73rnH0W69uTib2QkREa+LSfnsjU14O0Nv/wCfn7AZAJFwX/+A/Pnw+3bsHEjrF0LAF27dmWxWHRv66AzPqWWkXpyLH7xxRd0IlHBw4cPyTuQlJSk8k60OVJ/6dIlEnBeXh6d/QiFQjLTxdbWtsWsKbUjU4AXLlxIf1dcLveTTz4BgO7du7eYCKUuVVVV5B0+cuRIqzYkgzwcDicnJ6d5uRZG6h88eEBiTk5OVssOyQVoHR0dmXOktGfyZAqAGj/+Hc3c3CgAKiKiZfnq1RQAZW1NSU1QoebMoQCobt0kBQ0NDTSDbeOR+uLi4tOnTzMYjCVLlmj5pR0cHMjtz48ePdLyS6vGiZyt0Av4zZs3n3322X//+9+OHTtevXpVo11++CtmtbzDRkZGW7ZsAYCioqLLly/T36E0MzMzKysraGXAlZWVERERADBgwIAbN27ENvPkyRMAyM7Ojo2N/f333zURc48ePchA/B9//KGWHQYGBgKASCTKy8tTyw5VRK6KPn6sqI1QCCRI6WvZZC5HdTVI9/3JBbenT+Gv0RdymYgWOjmYfm+UnOaPGzeOThgq8/DwAIBRo0apvActzxslg6oqT5h//fp1QEAAAJibm2dlZak3NpnIlEY2m11RUaGWHZK7D6KiotSyN2kTJkwAgF69eim/yYkTJ5T5oil5E4oKyN3VdA7j5sioIABcv35dLTtU0eXLb2/cfPxYbpvz59+2kb519eLFt1XSU4x//fXtvH0eT13BtmVvtKamhpxBkHSsfTNmzACAxMTEmzdvtkkArUVOEn/55Rcyx6VVsrOzBw0adO3atT59+ty9e9fNzU0DAbYUFhbGYrGEQqGCwWuZZE4bqK+vJwPKSq4PogJySGRnZ588eVLJTZydnVfIQQZU3d3dV6xYIb1EgLqQ+8RUOIwlwwPNkdt2GQyG5OynbQQEABlC3LBBdgOx+G3V0KHg7Nyy1seHjCDBX5fC/ic5GQCgWzd418JDrUAnB7eqN3ru3Ll169YdOHBAUku+Wv369RNr/jYDmbhcroODAwDY2NhkZGS0qOXz+ZLbAdPT02NjY6VXKtFyb7S0tJTMPHdycnry5EmL2rq6Osl9LMnJybGxsb/99ht5eujQIbKYU1BQUG1trXaiJb788ksAYDKZ0dHR0h/0zZs3ydIklZWV5ET49evXly5dMjQ0jI2NbdGYzDZjMpnSf7u6CIVCMjZtamp67do16dobN26Qx+RUff/+/Qr2pp27mJQ/jNPS0iSH8eXLlx0cHFrc8FpSUuLs7AwAo0eP1mjMSjl27G2PcsMGuTeD6uhQqalvC2/fpmJjqZMn3z6dNo0CoLp3p169+t+GqamUri4FQH37rRoj1V4anTNnDgD4+vqSKoFAQC7MtfZyvnrdvXuXzBTR0dGZPHnyjh074uPjf/755y+++MLc3NzY2Li+vp6iqFWrVpHkRbZau3Yt6W5MnToVAFgslqQDoviGa/ouXrxIJtlwOJywsLCYmJhff/1169atM2fONDIysrOzI/eDkh6Kn5+fUCgkjwGgc+fOX3/9tXSnSXNZiaKohoYGycpDHh4e69evP3bs2L59+1auXEnuPSfrD2VkZJA2WVlZe/fuJQPQI0eO3LVrV0JCQmxsrOT2tgULFmguWoqi8vPzu3TpAgAMBmPMmDFRUVG//vrrrl27Fi1aZG1tzWQyybjczp07AUBfX1/BrrSTRimlD+OVK1eSw1gsFvv5+ZG/cfTo0Vu2bNm7d29ERAS5ZmJlZaXpw1hZ4eFvM6mnJ7V1K3XuHHXmDPXjj5Sz89sT823b/tc4IoICoPr2ffu0sJAyM6MAKFtbas0aavduav58Sk+PAqBcXSkuV41hai+Nfv3113Z2dpMmTSJVhw4dAgBbW1vpe721LCcnp8WSSBJDhgwh35lvv/2WzWb36dOHbEKONpmuXLmi6YDT0tLIaiMtkK9EVVUVRVFz5sxhs9mBgYFkPrliiYmJGg2Yx+MtXbpU768Jz83Z2NicOnWKoqisrCw2m81msx8+fEhR1JkzZ6TvZdLR0bJo0eYAABCSSURBVFm6dKnm1iWReP78+eTJk2XO1nJzcyMRxsTEsNlsU1NTBfvRWhqllDuM16xZIzmM6+vrIyIipO9YHTp0aHtZJY/YvZuyspKxUJ69/f86nsTy5RSbTXl4/K/k3r23Cbf5f4GBMi6Y0kNr2ea8vLzCwkJLS0t5c3QzMzPLysrs7OxIv6O5R48elZWVWVtbK3P3hRbk5eWR9W5ra2vNzMycnJyGDBlCzpWkHTx4UCAQyKwaN24cWW5HoyiKevjw4Y0bN168eMHj8czMzFxdXYcNGyb90gKB4ODBg4r3pp2Yq6qqEhMTs7OzKysrDQwMunTp4unpOWjQIHm3/zY2Nl6/fj0tLa2iokJfX9/Z2Xns2LGkn6gdxcXFiYmJxcXF1dXVpqamDg4Ovr6+rVpUMCkp6cmTJ9pctrlVhzEAVFdXX716NTc3t6GhwcbGxt/fv1+/ftoJtRV4PLh+He7cgbIyYLGgc2cYOlTZZZuFQkhKgrQ04HKhc2cYPlzNS+QBAP4jIip4/vy5UCgks3bbOhalVFdXV1dXm5ubd3jnPSFIVSUlJY2Njba2tlpbkQS1H+1lhaf3iJ+fX48ePdR7Q7dGbd++vUePHmQRz/dCcXGxjY0NWcbtffHxxx/36NFDcoW3/fvPf/5jYmLSVpNkPjDvR38K/b9C7v5Uw6RoJJ9AIOByuWR1EkQT9kYRQogWTKMIIUQLplGEEKIF0yhCCNGCaRQhhGjBNIoQQrRgGkUIIVowjSKEEC2YRhFCiBZMowghRAumUYQQogXTKEII0YJpFCGEaME0ihBCtGAaRQghWjCNIoQQLZhGEUKIFkyjCCFEC6ZRhBCiBdMoQgjRgmkUIYRowTSKEEK0YBpFCCFaMI0ihBAtmEYRQogWTKMIIUQLplGEEKIF0yhCCNGCaRQhhGjBNIoQQrRgGkUIIVowjSKEEC2YRhFCiBZMowghRAumUYQQogXTKEII0YJpFCGEaGG1dQDvnwkTJpSXlxsZGbV1IMpydnYeP368s7NzWweiLENDw3HjxtnY2LR1IK0wZMgQS0tLc3Pztg5EWfb29uPGjevbt29bB/IhYFAU1dYxtGv19fXV1dVsNrtz584yG9TU1HC5XH19fUtLS3k7EYvFf/75p729va6uLinh8XhlZWUKXpfFYnXt2lWFgCmKqqmpAQATExMdHR3pBiKRqK6uDgA6dOjAYDBk7qS+vr6oqKiurq5Lly7dunVTIYxWqa+vFwqFenp6+vr6MhvU1dWJRCIDAwMOhyNvJwKBoK6uTt6nQFFUWVnZ06dPGQyGo6MjzXwnEAgaGhqYTKapqanMBo2NjXw+n8ViGRsbK9hPWVmZlZWVzI8JAF6/fl1cXCwQCOzs7Lp06UInYACoqamhKMrY2JjFktF5khw2pqamTKbck9Ta2loWi2VoaKjghQQCQUFBQVVVlYWFhb29vZ6eHs3I3wMUUmjbtm0A4OrqKq9BeHg4AIwZM0ZmLY/Hi4mJIT1BDocjKb9w4YLiz8Xe3l61gCsqKsge7t27J7NBeno6aVBZWSlz81mzZjVPZ66urqdPn1YtGCV99NFHAPDVV1/Ja0DewKioKJm1lZWVP/74o7W1NQBMnjy5Ra1YLI6NjXVxcZH8RUwmMzAw8PHjxyoHfPToUQAwNzeX12D9+vUA4OHhIbNWJBKdOnVq6NChAKCnp1ddXd2iQVJS0vDhw5sfD7169Tpx4oTKAVMURX4yL1y4ILP26dOn5IXkvS05OTnz5s3T19dnMBh79uyR2aawsDAsLKz5LweHwwkLC3v58iWdyNs/PKnXlIqKil27du3cubOyspKUvHnzRlJramo6YMAAmRu+fPmyrKzMwMBAG1H+3YsXL3x8fF68eMFgMDw9PS0sLDIyMnJyckJCQmJiYv7xj39oPyTFCgoKoqOj9+3b19DQQEokDwixWDx9+vS4uDgAcHFxcXZ2rqqqSktLS0xMHDRo0K1bt/r06aPNgBsbG+Pj43/66afc3FxJiUgkat4mJiZm0aJFIpGIBNzU1JSWlpadnR0aGvrvf/970aJF2gwYAFJTU6Ojo0+dOiWJk8fjSTdLSkoKCgpqaGjQ0dHx9va2s7Orrq7OzMy8ffu2hYWFdkPWurbO4+2dyr3RkJAQALC0tJw1a9a3334LADo6Osq84sCBAwFg8+bNqgVMpzcaGBhIYr59+zYpaWxs/OKLLwBAX1+/qKhItZDeSbXeaFNTU4cOHQDA1tZ2/vz5wcHB0h/E3r17AcDY2PjMmTOSwocPH3bs2BEA/P39VQtY5d4o+SnS09MbP378d999J/1BPHjwgMViGRgYnDp1SlJYV1c3duxY8imQc3MVqNYbTUlJIeXu7u7fffddz549pT8IsjnphA4bNqz5cdLY2FhcXKxawO8RHKnXlLVr1yYnJ5eVlR04cICkJ2UkJyenpaUZGxvPnTtXo+FJy87OTkxMBICoqKhBgwaRQg6Hs3Pnzu7du/P5/JiYGC2HpJiuru6+ffvS0tKeP3++e/dumf3Kfv36BQcHx8TETJgwQVLYt2/fVatWAUBycrLkXEE7Fi9efPLkycrKynPnzk2bNk26ga2t7ZIlS6KiosjPMGFsbLxp0yYA4PP5kl9B7fD19Y2JiSkqKsrMzFy3bp2ZmZnMZqtWreJyuQ4ODufPn7e3t5eUczgcLVxbb3N4Uq8pbm5uKmy1detWAJg7dy7pZ2nTvXv3AIDFYoWGhjYvZ7PZkydP3rx589mzZzdu3KjlqBSbNGmS4gYDBw5MSEiQLvfx8QEAiqKKiooUjA2qXe/evXv37q2ggYWFxebNm6XLJWNrMgeINIfBYLzzYk5NTc2pU6cA4JtvvnmPZrCoEaZRdSouLi4uLtbX1/f29lZh8/z8/AsXLujo6Gjt+ldTU9Mff/wBAK6urtXV1QCgr68vPRpOxmfy8/MbGxvbfOA1Nze3vr6+Y8eOqs1kICTJiM1mqykuuV69evX06VMdHZ3+/furvBNyomBsbOzu7q6+0GQTiUSZmZkA0LNnT2V+zlNTUxsbGxkMxsSJEzUdW/uEJ/XqtH//fn9/f5kna8rYunWrWCyePHmyg4ODegOT59mzZ15eXl5eXllZWWRKDZfLffbsWYtm5LxMJBKVl5drJzAFZs2a5eXltWHDBjo7IT8eurq6PXr0UFNccsXHx3t5eZFxeRU0NDTs2LFj+fLlDAbjX//6lxZOU+rr68lRkZSUpEz7rKwsALCzs7OwsLh161ZERMT48eMnTpy4du3awsJCDQfbLmBvVCm5ubnyemHNx9/pePXq1ZEjRwAgIiJCLTsMDAyUeQIoL+CRI0caGho2NDQsX7786NGjkm5aYWHhDz/8QB6TCacaEhsbe+zYMZlVpKesRv/5z38AIDAwUPG8TsWqq6utrKxkVskcy24tHx+fZ8+elZaWUhTVvXv3Y8eONb/Cq5pp06bJ7ICLxWKV90l+XA0NDYODg8+ePSspP3PmzKZNm3bt2jV79myVd/5ewDSqFAaDIW9mOJ/Pl0wEiYyM/Pzzz1U7T9y5cyefzx86dKhqFwSk1dfXyyynmt1w0a1bN9Ivc3BwMDAwWL9+fURERHx8/KNHj0aNGmVkZJSRkZGYmCjZRKOnwE1NTUKhUGZV8ylBcXFxPB6Pzvz5EydO3Lx5k8FgrF69WuWdQLMp69KaZ6Vp06b5+fnJm2OvmI6ODovFEgqFL168+PXXX319fWlOHqqvr5d3z4WEsbExOSqUHB3icrkAkJOTU1RUtHDhwuDg4M6dOxcUFPz000/p6enz5s1zcXEhF6M/WG06T+A9QHP6PfH777+DwglPfD6/U6dOAJCQkEArXNrT76Ojo01MTCSHB4PBmDBhwv79+8lTDc2jpjn9niA5UfEHQVFUTk4OufVIwcu9E83p95JIFHwQEmKxODk52dPTEwD69u3b1NSkWsw0p98TXl5e0h/E559/DgDW1tZ5eXnNy/l8PpkgNWnSJNVifl/gtdF24eDBg+Xl5Y6OjkFBQW0byeLFi0tKSs6fPx8bG3v8+PGioqIzZ86QzqChoSHJ9e+v/Pz8wMDA2trakJCQLVu2tHU4SmEwGH5+fhcvXtTT0/vjjz/kXfdoQ+TCiImJiZOTU/NyPT29sLAwAEhNTW2byLQFT+rbHkVR0dHRALBkyRIFtzNrjaGhIZnsLXH79m0AcHNzU+3MtJ1IT08PDg4uLS0dO3bs8ePHtTxziCZLS8tevXplZGSkp6e3t0uNZJju2bNn1F99Xgmyvoy8Sx8fjLb/0qJz587l5OSYm5vPnDmzrWORob6+nswKfOckzfbs+PHjfn5+paWln3766cmTJyVrxLxHyEQ0Pp/f1oG0RC448Pn8x48ft6jKy8sDAPrrqrRzmEbVicfjvXr1qqqqqlVbkSn3CxYsULxwjiZQFMXn8/l8voKB2mXLltXU1HTo0GHGjBnajE2epqYmPp8vbzBKmkAgiIyM/PTTT4VC4ZYtW44dO6blqa8ikYjP5zc2NirTWCgUzpw5U/osuLi4mMwr0s7Sdu88Kpojd9ADQFRUVPPyioqKw4cPA0CLk5sPD6ZRddq4cWPHjh3JjzMAPHjw4P79+/fv38/PzwcAiqLu/6W2tpa0uXfv3o0bNzgczpdffqn9gP/8808DAwMDAwNy2s7lcjdu3Jifny8UCpuamu7cuTNp0qQ9e/YAQFRUlLzJPVrm5+dnYGCwePFiAGhqair8C5kUxePxJCUURRUVFQ0ZMiQqKkpXV3fnzp0hISGFf9fa3zwVxMTEGBgYSO6VevHiBXnp58+fk5KnT5+SEi6XGxcXd/jw4VGjRm3cuJGMFgqFwqSkpPHjx/P5fFNTUy38mNXW1pKj4syZMwBQU1MjebuampoA4PXr1+RpaWkpADCZzLVr1wLA/v37IyMji4qKGhoaEhMTR4wY8erVK1NTU3XN4Wu/2nSA6z3QqpF6sgRJ9+7dSZWCuSnnz58nbaZMmQIAs2fPVlfArRqpJ/kdAFJTUymKWrlyJXna/AqXvr7+7t271RWeTK0aqScTwv7xj39QFEVuYJVHKBS+c/bYqlWrVAi4VSP1O3bsAABDQ0NS1atXL3nBHDhwgKKoNWvWSK5BGxoaSq7hdujQ4fr16ypESyg/Ui+5lEmWR1Fwp0NAQADZXCwWkx+2FszMzC5fvqxyzO+L9+kqe5vo0aNHUFCQgvsO+/btGxQURHqgYWFh3t7ekjXugoODyZQ6aWRxTD6fz2QyQ0NDly1bpq6AdXV1yVKV8iaWm5iYkAZsNtva2vr48eMAQPLUokWL2Gx2UlJScXExk8ns2rXr8OHD586dq+nVJdzc3JqamhwdHeU18Pb2tra2JmeOP/74Y2VlJZlJY2JiomDZFwaD4eHhoXiCvWp3MXXu3Hn48OHy1mwGAHt7++HDh5N39aOPPjp+/Lhkyq2Pj4+8hf1J+T//+c+QkJC9e/f+/vvvL1++NDU17dKly9ixYxcvXkwOG9X4+/uLxWJ5P+16enrkqDA0NDQwMCBHBVlsrHv37vLeZMntrQwGIzo6ety4cfv27Xvw4EFtba2dnd2oUaMWLFjwwV8YBVz9HiGEaMJrowghRAumUYQQogXTKEII0YJpFCGEaME0ihBCtGAaRQghWv4PZ7H2OImRxnIAAADPelRYdHJka2l0UEtMIHJka2l0IDIwMjEuMDMuNQAAeJxtz8kNwjAQBdDvJfsuIciRC8hdJD3QECVQQhqgBeIrFEELtICd4LFBjDTyO4xned2uT5goTTKs0ZlsTZ5ZrPbmlT2BOwgH6RClarJNWB8zpVYlpJSUkXJSQSpJFakmNaSW1BV28RhI7NaMg6VgGbgAz8ELCAlRQlSQEWQN2WCDnTvV3jpqUOgZf0MP3uPofQmtH/fT4VOj/R/b0/VdHPQiH4Oa4ceDn/vlOZi1ePsGKiAp2/LMUikAAAEGelRYdE1PTCByZGtpdCAyMDIxLjAzLjUAAHicnZTBDsIgDIbvPEVfwIXC2ORoxMTEqIkH38G77x9HVWik2wTCof+Ab1B+qiC2Wzg9npCaCUoBjoADgBa79x7uRmutpukb202Rjiv1b7SHOQR1fAdEwc41UkymlGv/plhGad9LzyjteXGM0s/v5VpSkMUDy+4C5bi8l5FR8omKDK1QttJNl3e+QvGiXyopqEW/1FJQotSeCLl3m/OCsndrKbJ3aylOolSfiHu3nZK9i1QmMImRiy0TmEcMFYUsPBPRRB9h6dUnEY2RRf5pT886CbRcZICjd5sEOi6+I+epZu8CiTgbTPxyuAT1AtqJ5B7EhZN/AAABA3pUWHRTTUlMRVMgcmRraXQgMjAyMS4wMy41AAB4nG2SvW7DMAyEX6WjDViGKFF/zFRk6ZKku+ECKZCthoOg3fLwpSklGaSFx/t0ECGI055g7qY9GalWKkp1XE/k576bPgjc3G/ysDZbLBayNdmm7HR2IUvMMMxv907ZQQ87BaPbVG+l9HKAj36DLBKUxKuTRmfBEVHHdFHgS0K9wuqZVihdtD4Fye5UGaHKjH74AnLD+XddPm/rlfS4rD/v7A7n6/Fv+b7cRiCooSFTQ0u2hkhYQ0euhp58Y7qj0KCeYoNaSg2K/DENzO9qPAwMf2qNEy9AI6x5IWoceHlqGnmXGleE+z+GM8EHL/Cq9gAAAABJRU5ErkJggg==",
+      "image/svg+xml": [
+       "<?xml version='1.0' encoding='iso-8859-1'?>\n",
+       "<svg version='1.1' baseProfile='full'\n",
+       "              xmlns='http://www.w3.org/2000/svg'\n",
+       "                      xmlns:rdkit='http://www.rdkit.org/xml'\n",
+       "                      xmlns:xlink='http://www.w3.org/1999/xlink'\n",
+       "                  xml:space='preserve'\n",
+       "width='800px' height='300px' viewBox='0 0 800 300'>\n",
+       "<!-- END OF HEADER -->\n",
+       "<rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='800' height='300' x='0' y='0'> </rect>\n",
+       "<path d='M 43.6967,99.5297 L 69.0783,143.492' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:10px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 69.0783,143.492 L 119.841,143.492' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:10px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 330.163,135.031 L 286.201,160.413' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:10px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 711.839,136.869 L 668.397,163.131' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:10px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='69.0783' cy='143.492' rx='10.1526' ry='10.1526' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='119.841' cy='143.492' rx='10.1526' ry='10.1526' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='286.201' cy='160.413' rx='10.1526' ry='10.1526' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='711.839' cy='136.869' rx='10.1526' ry='10.1526' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='668.397' cy='163.131' rx='10.1526' ry='10.1526' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='623.933' cy='138.639' rx='10.1526' ry='10.1526' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-0' d='M 48.5814,107.99 L 69.0783,143.492' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-1' d='M 69.0783,143.492 L 48.5814,178.993' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-2' d='M 69.0783,143.492 L 119.841,143.492' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-2' d='M 76.6927,133.339 L 112.227,133.339' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-3' d='M 119.841,143.492 L 140.338,178.993' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-4' d='M 119.841,143.492 L 140.338,107.99' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-5' d='M 322.83,139.265 L 286.201,160.413' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-6' d='M 286.201,160.413 L 249.572,139.265' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-7' d='M 748.97,157.322 L 711.839,136.869' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-8' d='M 711.839,136.869 L 710.988,94.5772' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-9' d='M 711.839,136.869 L 668.397,163.131' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-9' d='M 710.575,149.497 L 680.166,167.88' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-10' d='M 668.397,163.131 L 669.248,205.423' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-11' d='M 668.397,163.131 L 623.933,138.639' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-12' d='M 623.933,138.639 L 586.802,118.187' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-13' d='M 623.933,138.639 L 604.102,174.643' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-14' d='M 623.933,138.639 L 643.764,102.636' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='49.3378' y='102.068' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='49.3378' y='189.992' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='139.582' y='189.992' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='139.582' y='102.068' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='324.522' y='137.569' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='247.88' y='137.569' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='750.662' y='163.899' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='705.176' y='88.6548' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='663.778' y='216.421' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='585.11' y='116.686' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='605.082' y='185.641' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='642.783' y='96.7132' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='52.1573' y='146.03' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>1</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='111.381' y='160.684' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>2</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='286.201' y='179.872' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>3</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='726.32' y='130.654' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>1</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='668.056' y='148.751' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>2</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='628.64' y='157.43' style='font-size:16px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>3</tspan></text>\n",
+       "<path d='M 283.72,152.798 L 283.716,152.711 L 283.705,152.624 L 283.686,152.539 L 283.66,152.456 L 283.627,152.375 L 283.587,152.297 L 283.541,152.223 L 283.488,152.153 L 283.43,152.088 L 283.366,152.028 L 283.298,151.974 L 283.224,151.926 L 283.148,151.885 L 283.067,151.85 L 282.985,151.823 L 282.9,151.802 L 282.813,151.789 L 282.726,151.783 L 282.639,151.785 L 282.552,151.795 L 282.466,151.811 L 282.382,151.835 L 282.301,151.867 L 282.222,151.905 L 282.147,151.95 L 282.076,152.001 L 282.01,152.058 L 281.949,152.12 L 281.893,152.188 L 281.844,152.259 L 281.801,152.335 L 281.764,152.415 L 281.735,152.497 L 281.712,152.582 L 281.697,152.668 L 281.69,152.755 L 281.69,152.842 L 281.697,152.929 L 281.712,153.015 L 281.735,153.1 L 281.764,153.182 L 281.801,153.261 L 281.844,153.337 L 281.893,153.409 L 281.949,153.477 L 282.01,153.539 L 282.076,153.596 L 282.147,153.647 L 282.222,153.692 L 282.301,153.73 L 282.382,153.761 L 282.466,153.785 L 282.552,153.802 L 282.639,153.811 L 282.726,153.813 L 282.813,153.808 L 282.9,153.795 L 282.985,153.774 L 283.067,153.746 L 283.148,153.712 L 283.224,153.67 L 283.298,153.622 L 283.366,153.568 L 283.43,153.508 L 283.488,153.443 L 283.541,153.374 L 283.587,153.3 L 283.627,153.222 L 283.66,153.141 L 283.686,153.058 L 283.705,152.972 L 283.716,152.886 L 283.72,152.798 L 282.704,152.798 Z' style='fill:#000000;fill-rule:evenodd;fill-opacity=1;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;' />\n",
+       "<path d='M 290.714,152.798 L 290.71,152.711 L 290.699,152.624 L 290.68,152.539 L 290.654,152.456 L 290.621,152.375 L 290.581,152.297 L 290.535,152.223 L 290.482,152.153 L 290.424,152.088 L 290.36,152.028 L 290.292,151.974 L 290.219,151.926 L 290.142,151.885 L 290.061,151.85 L 289.979,151.823 L 289.894,151.802 L 289.807,151.789 L 289.72,151.783 L 289.633,151.785 L 289.546,151.795 L 289.46,151.811 L 289.376,151.835 L 289.295,151.867 L 289.216,151.905 L 289.141,151.95 L 289.07,152.001 L 289.004,152.058 L 288.943,152.12 L 288.887,152.188 L 288.838,152.259 L 288.795,152.335 L 288.758,152.415 L 288.729,152.497 L 288.706,152.582 L 288.692,152.668 L 288.684,152.755 L 288.684,152.842 L 288.692,152.929 L 288.706,153.015 L 288.729,153.1 L 288.758,153.182 L 288.795,153.261 L 288.838,153.337 L 288.887,153.409 L 288.943,153.477 L 289.004,153.539 L 289.07,153.596 L 289.141,153.647 L 289.216,153.692 L 289.295,153.73 L 289.376,153.761 L 289.46,153.785 L 289.546,153.802 L 289.633,153.811 L 289.72,153.813 L 289.807,153.808 L 289.894,153.795 L 289.979,153.774 L 290.061,153.746 L 290.142,153.712 L 290.219,153.67 L 290.292,153.622 L 290.36,153.568 L 290.424,153.508 L 290.482,153.443 L 290.535,153.374 L 290.581,153.3 L 290.621,153.222 L 290.654,153.141 L 290.68,153.058 L 290.699,152.972 L 290.71,152.886 L 290.714,152.798 L 289.698,152.798 Z' style='fill:#000000;fill-rule:evenodd;fill-opacity=1;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;' />\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='193.731' y='153.6' style='font-size:24px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>+</tspan></text>\n",
+       "<path d='M 378.672,150 L 514.04,150' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 514.04,150 L 508.178,146.616' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 514.04,150 L 508.178,153.384' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "</svg>\n"
+      ],
       "text/plain": [
-       "<rdmc.mol.RDKitMol at 0x7fab1a202450>"
+       "<rdmc.reaction.Reaction at 0x7fdc05c1bcd0>"
       ]
      },
-     "execution_count": 7,
      "metadata": {},
-     "output_type": "execute_result"
+     "output_type": "display_data"
     }
    ],
    "source": [
-    "p_complex"
+    "rxn = Reaction.from_reaction_smiles(atommapped_rxn_smi)\n",
+    "display(rxn)\n",
+    "r_complex = rxn.reactant_complex\n",
+    "p_complex = rxn.product_complex"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28f08cf8",
+   "metadata": {},
+   "source": [
+    "### Sort Heavy Atoms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a2d1c702",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# There are cases with unequal number of atoms labeled with atom map index. Known cases:\n",
+    "# - H will not be labeled in most case but will be labeled if there is a [H][H] or [H]\n",
+    "H_atoms = []\n",
+    "if max(r_complex.GetAtomMapNumbers()) != max(p_complex.GetAtomMapNumbers()):\n",
+    "    # There are H2\n",
+    "    H_atoms = [i - 1 for i in \n",
+    "               set(r_complex.GetAtomMapNumbers()).symmetric_difference(p_complex.GetAtomMapNumbers())]\n",
+    "\n",
+    "atommap_id_counter = max(r_complex.GetAtomMapNumbers()) + 1\n",
+    "for ratom in r_complex.GetAtoms():\n",
+    "    if ratom.GetAtomMapNum() == 0:\n",
+    "        ratom.SetAtomMapNum(atommap_id_counter)\n",
+    "        atommap_id_counter += 1\n",
+    "\n",
+    "atommap_id_counter = max(p_complex.GetAtomMapNumbers()) + 1\n",
+    "for patom in p_complex.GetAtoms():\n",
+    "    if patom.GetAtomMapNum() == 0:\n",
+    "        patom.SetAtomMapNum(atommap_id_counter)\n",
+    "        atommap_id_counter += 1\n",
+    "\n",
+    "r_complex = r_complex.RenumberAtoms()\n",
+    "p_complex = p_complex.RenumberAtoms()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebf6a71d",
+   "metadata": {},
+   "source": [
+    "### Map non-reacting H atoms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8f38fdd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check each heavy atoms and and match non-reacting H atoms assuming minimal bond change\n",
+    "\n",
+    "unused_ratom_ids = []\n",
+    "unset_patom_ids = []\n",
+    "for ratom in r_complex.GetAtoms():\n",
+    "\n",
+    "    # Skip H atoms\n",
+    "    if ratom.GetAtomicNum() == 1:\n",
+    "        continue\n",
+    "\n",
+    "    patom = p_complex.GetAtomWithIdx(ratom.GetIdx())\n",
+    "    rH_nbs, pH_nbs = [], []\n",
+    "    \n",
+    "    for rnb in ratom.GetNeighbors():\n",
+    "        if rnb.GetAtomicNum() == 1:\n",
+    "            rH_nbs.append(rnb.GetIdx())\n",
+    "    for pnb in patom.GetNeighbors():\n",
+    "        if pnb.GetAtomicNum() == 1:\n",
+    "            pH_nbs.append(pnb.GetIdx())\n",
+    "    \n",
+    "    for rH_idx, pH_idx in zip(rH_nbs, pH_nbs):\n",
+    "        p_complex.GetAtomWithIdx(pH_idx).SetAtomMapNum(\n",
+    "            r_complex.GetAtomWithIdx(rH_idx).GetAtomMapNum())\n",
+    "        \n",
+    "    if len(rH_nbs) > len(pH_nbs):\n",
+    "        unused_ratom_ids.extend(rH_nbs[len(pH_nbs):])\n",
+    "    elif len(rH_nbs) < len(pH_nbs):\n",
+    "        unset_patom_ids.extend(pH_nbs[len(rH_nbs):])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5728cef",
+   "metadata": {},
+   "source": [
+    "### Map reacting H atoms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "98e86a6c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if H_atoms:\n",
+    "    # Can only handle H2 generation without H migration\n",
+    "    if (len(unused_ratom_ids) == 0) and (len(unset_patom_ids) == len(H_atoms)):\n",
+    "        # There is H2 in reactants\n",
+    "        for rH_idx, pH_idx in zip(H_atoms, unset_patom_ids):\n",
+    "            p_complex.GetAtomWithIdx(pH_idx).SetAtomMapNum(r_complex.GetAtomWithIdx(rH_idx).GetAtomMapNum())\n",
+    "    elif (len(unset_patom_ids) == 0) and (len(unused_ratom_ids) == len(H_atoms)):\n",
+    "        # There is H2 in products\n",
+    "        for rH_idx, pH_idx in zip(unused_ratom_ids, H_atoms):\n",
+    "            p_complex.GetAtomWithIdx(pH_idx).SetAtomMapNum(r_complex.GetAtomWithIdx(rH_idx).GetAtomMapNum())\n",
+    "    else:\n",
+    "        raise Runtime('Unexpected behavior in atommapping')\n",
+    "else:\n",
+    "    assert len(unused_ratom_ids) == len(unset_patom_ids), 'Unexpected behavior when assigning H atommapping'\n",
+    "    if len(unused_ratom_ids) > 1:\n",
+    "        from itertools import permutations\n",
+    "        import numpy as np\n",
+    "\n",
+    "        min_num_bond_change = np.inf\n",
+    "        opt_pairs = []\n",
+    "        for pairs in permutations(zip(unused_ratom_ids, unset_patom_ids)):\n",
+    "            for rH_idx, pH_idx in pairs:\n",
+    "                p_complex.GetAtomWithIdx(pH_idx).SetAtomMapNum(r_complex.GetAtomWithIdx(rH_idx).GetAtomMapNum())\n",
+    "            formed, broken = get_formed_and_broken_bonds(r_complex, p_complex.RenumberAtoms())\n",
+    "            if len(formed + broken) < min_num_bond_change:\n",
+    "                opt_pairs = pairs\n",
+    "    elif len(unused_ratom_ids) == 1:\n",
+    "        opt_pairs = ((unused_ratom_ids[0], unset_patom_ids[0]),)\n",
+    "    else:\n",
+    "        opt_pairs = tuple()\n",
+    "\n",
+    "    for rH_idx, pH_idx in opt_pairs:\n",
+    "        p_complex.GetAtomWithIdx(pH_idx).SetAtomMapNum(r_complex.GetAtomWithIdx(rH_idx).GetAtomMapNum())\n",
+    "p_complex = p_complex.RenumberAtoms()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d0acdb2",
+   "metadata": {},
+   "source": [
+    "### Generate Reaction Smiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f5ecd19a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/svg+xml": [
+       "<?xml version='1.0' encoding='iso-8859-1'?>\n",
+       "<svg version='1.1' baseProfile='full'\n",
+       "              xmlns='http://www.w3.org/2000/svg'\n",
+       "                      xmlns:rdkit='http://www.rdkit.org/xml'\n",
+       "                      xmlns:xlink='http://www.w3.org/1999/xlink'\n",
+       "                  xml:space='preserve'\n",
+       "width='800px' height='300px' viewBox='0 0 800 300'>\n",
+       "<!-- END OF HEADER -->\n",
+       "<rect style='opacity:1.0;fill:#FFFFFF;stroke:none' width='800' height='300' x='0' y='0'> </rect>\n",
+       "<path d='M 77.1571,144.242 L 122.071,144.242' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 77.1571,144.242 L 54.7002,105.345' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 77.1571,144.242 L 54.7002,183.138' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 122.071,144.242 L 144.528,183.138' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 122.071,144.242 L 144.528,105.345' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 299.24,159.213 L 338.136,136.756' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 299.24,159.213 L 260.344,136.756' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 705.811,138.382 L 667.375,161.618' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 705.811,138.382 L 745.152,160.052' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 705.811,138.382 L 704.907,93.4778' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 667.375,161.618 L 668.279,206.522' style='fill:none;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 628.034,139.948 L 606.365,179.289' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 628.034,139.948 L 649.703,100.608' style='fill:none;fill-rule:evenodd;stroke:#FFCC99;stroke-width:9px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='77.1571' cy='144.242' rx='8.98274' ry='8.98274' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='122.071' cy='144.242' rx='8.98274' ry='8.98274' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='144.528' cy='183.138' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='144.528' cy='105.345' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='54.7002' cy='105.345' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='54.7002' cy='183.138' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='299.24' cy='159.213' rx='8.98274' ry='8.98274' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='338.136' cy='136.756' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='260.344' cy='136.756' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='705.811' cy='138.382' rx='8.98274' ry='8.98274' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='667.375' cy='161.618' rx='8.98274' ry='8.98274' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='628.034' cy='139.948' rx='8.98274' ry='8.98274' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='588.694' cy='118.279' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='606.365' cy='179.289' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='649.703' cy='100.608' rx='9.17561' ry='10.5863' style='fill:#FFCC99;fill-rule:evenodd;stroke:#FFCC99;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='668.279' cy='206.522' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='745.152' cy='160.052' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<ellipse cx='704.907' cy='93.4778' rx='9.17561' ry='10.5863' style='fill:#FFFFAA;fill-rule:evenodd;stroke:#FFFFAA;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-0' d='M 77.1571,144.242 L 122.071,144.242' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-0' d='M 83.8942,135.259 L 115.334,135.259' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-3' d='M 77.1571,144.242 L 59.0221,112.831' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-4' d='M 77.1571,144.242 L 59.0221,175.652' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-1' d='M 122.071,144.242 L 140.206,175.652' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-2' d='M 122.071,144.242 L 140.206,112.831' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-5' d='M 299.24,159.213 L 331.648,140.502' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-6' d='M 299.24,159.213 L 266.832,140.502' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-7' d='M 705.811,138.382 L 667.375,161.618' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-7' d='M 704.693,149.555 L 677.787,165.82' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-13' d='M 705.811,138.382 L 738.664,156.478' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-14' d='M 705.811,138.382 L 705.058,100.963' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-8' d='M 667.375,161.618 L 628.034,139.948' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-12' d='M 667.375,161.618 L 668.128,199.037' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-9' d='M 628.034,139.948 L 595.182,121.853' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-10' d='M 628.034,139.948 L 610.488,171.803' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path class='bond-11' d='M 628.034,139.948 L 645.58,108.093' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='139.537' y='185.384' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='139.537' y='107.591' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='59.6913' y='107.591' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='59.6913' y='185.384' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='333.145' y='139.002' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='265.335' y='139.002' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='593.685' y='120.524' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"end\" x='611.356' y='181.534' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='644.712' y='102.853' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='663.288' y='208.768' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='740.161' y='162.297' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"start\" x='699.916' y='95.7235' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>H</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='62.1859' y='146.487' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>1</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='114.585' y='159.453' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>2</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='157.493' y='192.869' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>6</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='131.562' y='100.105' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>7</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='41.7348' y='100.105' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>4</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='67.6657' y='192.869' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>5</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='299.24' y='176.43' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>3</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='351.102' y='131.516' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>8</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='247.378' y='131.516' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>9</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='718.623' y='132.883' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>1</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='667.073' y='148.895' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>2</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='632.199' y='156.574' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>3</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='575.58' y='113.301' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>7</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='619.478' y='188.758' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>8</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='636.59' y='95.6302' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>9</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='681.392' y='215.991' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>6</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='758.265' y='169.521' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>4</tspan></text>\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='691.794' y='88.5003' style='font-size:14px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>5</tspan></text>\n",
+       "<path d='M 297.044,152.476 L 297.041,152.399 L 297.031,152.322 L 297.014,152.246 L 296.992,152.173 L 296.962,152.101 L 296.927,152.032 L 296.886,151.967 L 296.84,151.905 L 296.788,151.848 L 296.732,151.795 L 296.671,151.747 L 296.606,151.704 L 296.538,151.668 L 296.467,151.637 L 296.394,151.613 L 296.319,151.594 L 296.242,151.583 L 296.165,151.578 L 296.088,151.579 L 296.011,151.588 L 295.935,151.603 L 295.861,151.624 L 295.789,151.652 L 295.719,151.685 L 295.653,151.725 L 295.59,151.77 L 295.532,151.821 L 295.478,151.876 L 295.428,151.935 L 295.385,151.999 L 295.346,152.066 L 295.314,152.137 L 295.288,152.209 L 295.268,152.284 L 295.255,152.36 L 295.249,152.437 L 295.249,152.515 L 295.255,152.592 L 295.268,152.668 L 295.288,152.742 L 295.314,152.815 L 295.346,152.885 L 295.385,152.953 L 295.428,153.016 L 295.478,153.076 L 295.532,153.131 L 295.59,153.182 L 295.653,153.227 L 295.719,153.266 L 295.789,153.3 L 295.861,153.328 L 295.935,153.349 L 296.011,153.364 L 296.088,153.372 L 296.165,153.374 L 296.242,153.369 L 296.319,153.357 L 296.394,153.339 L 296.467,153.315 L 296.538,153.284 L 296.606,153.247 L 296.671,153.205 L 296.732,153.157 L 296.788,153.104 L 296.84,153.047 L 296.886,152.985 L 296.927,152.919 L 296.962,152.851 L 296.992,152.779 L 297.014,152.705 L 297.031,152.63 L 297.041,152.553 L 297.044,152.476 L 296.146,152.476 Z' style='fill:#000000;fill-rule:evenodd;fill-opacity=1;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;' />\n",
+       "<path d='M 303.232,152.476 L 303.229,152.399 L 303.219,152.322 L 303.203,152.246 L 303.18,152.173 L 303.15,152.101 L 303.115,152.032 L 303.074,151.967 L 303.028,151.905 L 302.976,151.848 L 302.92,151.795 L 302.859,151.747 L 302.794,151.704 L 302.726,151.668 L 302.655,151.637 L 302.582,151.613 L 302.507,151.594 L 302.431,151.583 L 302.353,151.578 L 302.276,151.579 L 302.199,151.588 L 302.123,151.603 L 302.049,151.624 L 301.977,151.652 L 301.907,151.685 L 301.841,151.725 L 301.778,151.77 L 301.72,151.821 L 301.666,151.876 L 301.617,151.935 L 301.573,151.999 L 301.535,152.066 L 301.502,152.137 L 301.476,152.209 L 301.457,152.284 L 301.443,152.36 L 301.437,152.437 L 301.437,152.515 L 301.443,152.592 L 301.457,152.668 L 301.476,152.742 L 301.502,152.815 L 301.535,152.885 L 301.573,152.953 L 301.617,153.016 L 301.666,153.076 L 301.72,153.131 L 301.778,153.182 L 301.841,153.227 L 301.907,153.266 L 301.977,153.3 L 302.049,153.328 L 302.123,153.349 L 302.199,153.364 L 302.276,153.372 L 302.353,153.374 L 302.431,153.369 L 302.507,153.357 L 302.582,153.339 L 302.655,153.315 L 302.726,153.284 L 302.794,153.247 L 302.859,153.205 L 302.92,153.157 L 302.976,153.104 L 303.028,153.047 L 303.074,152.985 L 303.115,152.919 L 303.15,152.851 L 303.18,152.779 L 303.203,152.705 L 303.219,152.63 L 303.229,152.553 L 303.232,152.476 L 302.334,152.476 Z' style='fill:#000000;fill-rule:evenodd;fill-opacity=1;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;' />\n",
+       "<text dominant-baseline=\"central\" text-anchor=\"middle\" x='202.436' y='153.6' style='font-size:24px;font-style:normal;font-weight:normal;fill-opacity:1;stroke:none;font-family:sans-serif;fill:#000000' ><tspan>+</tspan></text>\n",
+       "<path d='M 396.044,150 L 515.814,150' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 515.814,150 L 510.628,147.006' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "<path d='M 515.814,150 L 510.628,152.994' style='fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1' />\n",
+       "</svg>\n"
+      ],
+      "text/plain": [
+       "<rdmc.reaction.Reaction at 0x7fdbf45d6c50>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[C:1](=[C:2]([H:6])[H:7])([H:4])[H:5].[C:3]([H:8])[H:9]>>[C:1](=[C:2]([C:3]([H:7])([H:8])[H:9])[H:6])([H:4])[H:5]\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_rxn = Reaction(r_complex, p_complex)\n",
+    "display(new_rxn)\n",
+    "print(rxn.to_smiles())"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "19a25df1",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -344,7 +856,7 @@
    "lastKernelId": null
   },
   "kernelspec": {
-   "display_name": "Python 3.7.12 ('arc_env': conda)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/xiaoruiDong/RDMC",
     packages=find_packages(),
-    install_requires=['numpy', 'py3Dmol'],  # you install rdkit and openbabel from environment.yml
+    install_requires=['numpy', 'py3Dmol', 'ase'],  # you install rdkit and openbabel from environment.yml
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
[RXNMapper](https://github.com/rxn4chemistry/rxnmapper) shows promising results in creating atom maps for random reactions. Recently, I did some preliminary tests and found it could also be used for radical reactions, which are not included in their training dataset. A demo workflow is added to the "Generate Atommapped SMILES.ipynb" for users to play with as another option besides using RMG templates.

The PR also involves a fix of adding "ASE" as a requirement to the `setup.py`.