### PR TITLE
Enable installation by conda

### DIFF
--- a/.conda/release/meta.yaml
+++ b/.conda/release/meta.yaml
@@ -1,0 +1,41 @@
+{% set name = "rdmc" %}
+{% set version = "0.1.0" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  path: ../../
+
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install --no-deps -vv ./
+  noarch: python
+
+requirements:
+  host:
+    - python>=3.6
+  run:
+    - numpy
+    - scipy
+    - rdkit>=2021.03.1
+    - openbabel>=3
+    - py3dmol
+    - ase
+    - networkx
+    - matplotlib
+    - cclib
+
+test:
+  imports:
+    - rdmc
+
+about:
+  home: https://github.com/xiaoruiDong/RDMC/
+  license: MIT
+  summary: "RDMC: a python package handling Reaction Data and Molecular Conformers."
+
+extra:
+  recipe-maintainers:
+    - xiaoruiDong

--- a/.github/workflows/PULL_REQUEST_TEMPLATE.md
+++ b/.github/workflows/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
+You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
+-->
+
+### Motivation or Problem
+A clear and concise description of what what you're trying to fix or improve. Please reference any issues that this addresses.
+
+### Description of Changes
+A clear and concise description of what what you've changed or added.
+
+### Testing
+A clear and concise description of testing that you've done or plan to do.
+
+### Reviewer Tips
+Suggestions for verifying that this PR works or other notes for the reviewer.
+
+<!--
+Checklist before submission:
+ - Have you added appropriate unit tests?
+ - Have you checked that all unit tests pass?
+ - Is your code commented and understandable?
+ - Have you updated related documentation?
+ - Are the commits logically organized and informative?
+ - Is your branch up to date with main?
+-->

--- a/.github/workflows/conda_build.yaml
+++ b/.github/workflows/conda_build.yaml
@@ -1,0 +1,38 @@
+name: Build and Publish Conda Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+        run:
+            shell: bash -l {0}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup Miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+            activate-environment: rdmc_env
+            environment-file: environment.yml
+            miniforge-variant: mambaforge
+            miniforge-version: latest
+            python-version: 3.7
+            auto-activate-base: true
+            use-mamba: true
+
+    - name: Conda info
+      run: |
+        conda info
+        conda list
+
+    - name: Build Conda package
+      run: |
+        mamba install -y conda-build anaconda-client boa
+        conda mambabuild --output-folder conda-bld ../.conda/release
+        anaconda -t ${{ secrets.ANACONDA_TOKEN }} upload --force conda-bld/noarch/**/rdmc-*.tar.bz2

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2020 Xiaorui Dong
+Copyright (c) 2020-2023 Xiaorui Dong
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 [![Documentation Status](https://readthedocs.org/projects/rdmc/badge/?version=latest)](https://rdmc.readthedocs.io/en/latest/?badge=latest)
 [![MIT license](http://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
 
-A light-weight software package with expertise in handling Reaction Data and Molecular (including transitions states) Conformers. For detailed APIs, please check the [documentation](https://rdmc.readthedocs.io).
+A light-weight software package with expertise in handling Reaction Data and Molecular (including transitions states) Conformers.
+
+The package can be easily installed with conda or mamba
+
+```
+conda install -c xiaoruidong rdmc
+```
+
+For detailed APIs, please check the [documentation](https://rdmc.readthedocs.io).
 
 ## Requirements
 * python

--- a/setup.py
+++ b/setup.py
@@ -7,22 +7,35 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="RDMC", # Replace with your own username
-    version="0.0.1",
-    author="Xiaorui Dong",
+    name="RDMC",
+    version="0.1.0",
+    author="Xiaorui Dong, Lagnajit Pattanaik, Shih-Cheng Li, Kevin Spiekermann, Hao-Wei Pang, and William H. Green",
     author_email="xiaorui@mit.com",
-    description="An RDKit Wrapper for molecule and conformer operation",
+    description="A light-weight software package with expertise in handling Reaction Data and Molecular (including transitions states) Conformers.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/xiaoruiDong/RDMC",
     packages=find_packages(),
-    install_requires=['numpy', 'py3Dmol', 'ase'],  # you install rdkit and openbabel from environment.yml
+    install_requires=['numpy',
+                      'scipy',
+                      # RDKit and OpenBabel are canceled out to avoid duplicated
+                      # installation by PyPI
+                      # OpenBabel also has installation issues at least on Mchip Mac
+                      # 'rdkit>=2021.03.1',
+                      # 'openbabel',
+                      'networkx',
+                      'py3Dmol',
+                      'ase',
+                      'matplotlib',
+                      'cclib'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Chemistry"
     ],
+    keywords="chemistry, RDKit, molecule, conformer, reaction",
     license = "MIT License",
     python_requires='>=3.6',
+    platforms=["Any."],
 )


### PR DESCRIPTION
Within the PR, the following is done:
1. Create a conda recipe to build conda package
2. Update the license file of the package, majorly extending the years
3. Update the setup.py file of the package, majorly extending/correcting the contents
4. Add a new Github Action for publishing conda package when a new version is released. I haven't tested it yet and leave it as a future work. A token is also added to the secret of this repo.
5. Update the README about the new way of installation
6. Add a Pull Request template (not relevant to this PR, but I am too lazy)

The conda package is published at channel `xiaoruidong` (my personal channel). As this is a pure python package, only `noarch` version is built and published.