### PR TITLE
Increase the number of elements included in the van der Waal radii dictionary

### DIFF
--- a/rdmc/utils.py
+++ b/rdmc/utils.py
@@ -61,7 +61,7 @@ ROTATABLE_BOND_SMARTS_WO_METHYL = Chem.MolFromSmarts(
 CARBENE_PATTERN = Chem.MolFromSmarts("[Cv0,Cv1,Cv2,Nv0,Nv1,Ov0]")
 
 PERIODIC_TABLE = Chem.GetPeriodicTable()
-VDW_RADII = {i: PERIODIC_TABLE.GetRvdw(i) for i in range(1, 36)}
+VDW_RADII = {i: PERIODIC_TABLE.GetRvdw(i) for i in range(1, 119)}
 
 
 def determine_smallest_atom_index_in_torsion(


### PR DESCRIPTION
### Motivation or Problem
Current version of RDMC has a dictionary of van der Waals radii, by assigning the `rdkit` computed van der Waals radii for all atomic numbers up to 35. However, this may be restrictive for use cases when someone wants to use a v.d.W. radius with a higher atomic number (such as Iodine, atomic number 53).

### Description of Changes
Changed the line creating the vdW radii dictionary to include atomic numbers up to 118.

### Testing
I tested to ensure that this change works for the following versions of RDKit:
`2020.03.3`
`2023.03.3`
