### PR TITLE
V0.5/fixparserbug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ coverage.xml
 
 # Django stuff:
 *.log
+!test/data/*.log
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/rdmc/utils.py
+++ b/rdmc/utils.py
@@ -5,6 +5,7 @@
 This module provides methods that can directly apply to RDKit Mol/RWMol.
 """
 
+import pathlib
 from typing import Iterable, Tuple, Union
 
 import numpy as np
@@ -27,6 +28,9 @@ from rdkit.Chem.TorsionFingerprints import CalculateTorsionLists
 # Mute RDKit's error logs
 # They can be confusing at places where try ... except ... are implemented.
 RDLogger.DisableLog("rdApp.*")
+
+
+repo_dir = pathlib.Path(__file__).absolute().parent.parent
 
 try:
     # Openbabel 3

--- a/test/data/gaussian_irc_with_correction_failed.log
+++ b/test/data/gaussian_irc_with_correction_failed.log
@@ -1,0 +1,7352 @@
+ Entering Gaussian System, Link 0=g16
+ Initial command:
+ /home/gridsan/nmorgan/RMG_shared/Software/gaussian_16_c02/g16/l1.exe "/tmp/24487558/Gau-315325.inp" -scrdir="/tmp/24487558/"
+ Entering Link 1 = /home/gridsan/nmorgan/RMG_shared/Software/gaussian_16_c02/g16/l1.exe PID=    315327.
+  
+ Copyright (c) 1988-2021, Gaussian, Inc.  All Rights Reserved.
+  
+ This is part of the Gaussian(R) 16 program.  It is based on
+ the Gaussian(R) 09 system (copyright 2009, Gaussian, Inc.),
+ the Gaussian(R) 03 system (copyright 2003, Gaussian, Inc.),
+ the Gaussian(R) 98 system (copyright 1998, Gaussian, Inc.),
+ the Gaussian(R) 94 system (copyright 1995, Gaussian, Inc.),
+ the Gaussian 92(TM) system (copyright 1992, Gaussian, Inc.),
+ the Gaussian 90(TM) system (copyright 1990, Gaussian, Inc.),
+ the Gaussian 88(TM) system (copyright 1988, Gaussian, Inc.),
+ the Gaussian 86(TM) system (copyright 1986, Carnegie Mellon
+ University), and the Gaussian 82(TM) system (copyright 1983,
+ Carnegie Mellon University). Gaussian is a federally registered
+ trademark of Gaussian, Inc.
+  
+ This software contains proprietary and confidential information,
+ including trade secrets, belonging to Gaussian, Inc.
+  
+ This software is provided under written license and may be
+ used, copied, transmitted, or stored only in accord with that
+ written license.
+  
+ The following legend is applicable only to US Government
+ contracts under FAR:
+  
+                    RESTRICTED RIGHTS LEGEND
+  
+ Use, reproduction and disclosure by the US Government is
+ subject to restrictions as set forth in subparagraphs (a)
+ and (c) of the Commercial Computer Software - Restricted
+ Rights clause in FAR 52.227-19.
+  
+ Gaussian, Inc.
+ 340 Quinnipiac St., Bldg. 40, Wallingford CT 06492
+  
+  
+ ---------------------------------------------------------------
+ Warning -- This program may not be used in any manner that
+ competes with the business of Gaussian, Inc. or will provide
+ assistance to any competitor of Gaussian, Inc.  The licensee
+ of this program is prohibited from giving any competitor of
+ Gaussian, Inc. access to this program.  By using this program,
+ the user acknowledges that Gaussian, Inc. is engaged in the
+ business of creating and licensing software in the field of
+ computational chemistry and represents and warrants to the
+ licensee that it is not a competitor of Gaussian, Inc. and that
+ it will not use this program in any manner prohibited above.
+ ---------------------------------------------------------------
+  
+
+ Cite this work as:
+ Gaussian 16, Revision C.02,
+ M. J. Frisch, G. W. Trucks, H. B. Schlegel, G. E. Scuseria, 
+ M. A. Robb, J. R. Cheeseman, G. Scalmani, V. Barone, 
+ G. A. Petersson, H. Nakatsuji, X. Li, M. Caricato, A. V. Marenich, 
+ J. Bloino, B. G. Janesko, R. Gomperts, B. Mennucci, H. P. Hratchian, 
+ J. V. Ortiz, A. F. Izmaylov, J. L. Sonnenberg, D. Williams-Young, 
+ F. Ding, F. Lipparini, F. Egidi, J. Goings, B. Peng, A. Petrone, 
+ T. Henderson, D. Ranasinghe, V. G. Zakrzewski, J. Gao, N. Rega, 
+ G. Zheng, W. Liang, M. Hada, M. Ehara, K. Toyota, R. Fukuda, 
+ J. Hasegawa, M. Ishida, T. Nakajima, Y. Honda, O. Kitao, H. Nakai, 
+ T. Vreven, K. Throssell, J. A. Montgomery, Jr., J. E. Peralta, 
+ F. Ogliaro, M. J. Bearpark, J. J. Heyd, E. N. Brothers, K. N. Kudin, 
+ V. N. Staroverov, T. A. Keith, R. Kobayashi, J. Normand, 
+ K. Raghavachari, A. P. Rendell, J. C. Burant, S. S. Iyengar, 
+ J. Tomasi, M. Cossi, J. M. Millam, M. Klene, C. Adamo, R. Cammi, 
+ J. W. Ochterski, R. L. Martin, K. Morokuma, O. Farkas, 
+ J. B. Foresman, and D. J. Fox, Gaussian, Inc., Wallingford CT, 2019.
+ 
+ ******************************************
+ Gaussian 16:  ES64L-G16RevC.02  7-Dec-2021
+                14-Dec-2023 
+ ******************************************
+ %nprocshared=8
+ Will use up to    8 processors via shared memory.
+ %mem=40GB
+ ------------------------------------
+ # wB97XD/Def2TZVP irc=calcfc scf=xqc
+ ------------------------------------
+ 1/10=4,18=10,26=3,38=1,44=3,172=1/1,23;
+ 2/12=2,17=6,18=5,29=1,40=1/2;
+ 3/5=44,7=101,11=2,25=1,30=1,71=2,74=-58,140=1/1,2,3;
+ 4//1;
+ 5/5=2,8=3,13=1,38=5/2,8;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1,13=1/2;
+ 6/7=2,8=2,9=2,10=2,28=1/1;
+ 7/10=1,25=1/1,2,3,16;
+ 1/10=4,18=10,26=3,44=3/23(2);
+ 2/29=1/2;
+ 99/5=20/99;
+ 2/29=1/2;
+ 3/5=44,7=101,11=2,25=1,30=1,71=2,74=-58,140=1/1,2,3;
+ 4/5=5,16=3,69=1/1;
+ 5/5=2,8=3,13=1,38=5/2,8;
+ 8/6=4,10=90,11=11/1;
+ 11/6=1,8=1,9=11,15=111,16=1/1,2,10;
+ 10/6=1,13=1/2;
+ 7/10=1,25=1/1,2,3,16;
+ 1/18=10,26=3,44=3/23(-8);
+ 2/29=1/2;
+ 6/7=2,8=2,9=2,10=2,19=2,28=1/1;
+ 99/5=20,9=1/99;
+ -----
+ Title
+ -----
+ Symbolic Z-matrix:
+ Charge =  0 Multiplicity = 2
+ C                    -2.60546   1.4       0.64069 
+ C                    -1.84563   0.13455   0.27997 
+ O                    -2.61874  -0.7134   -0.55754 
+ C                    -0.55806   0.44454  -0.46429 
+ C                     0.22916  -0.81486  -0.88756 
+ C                     0.69171  -1.64145   0.23446 
+ O                     1.72907  -1.31416   0.97038 
+ H                    -3.52617   1.16235   1.17921 
+ H                    -2.86872   1.95377  -0.26256 
+ H                    -2.00238   2.04452   1.28268 
+ H                    -1.59194  -0.40321   1.2053 
+ H                    -3.45673  -0.89061  -0.12842 
+ H                    -0.79665   1.01525  -1.36541 
+ H                     0.06268   1.08463   0.16508 
+ H                     1.10595  -0.475    -1.46256 
+ H                    -0.40746  -1.41938  -1.53291 
+ H                     0.18688  -2.54248   0.55713 
+ H                     2.02849  -0.3864    0.81798 
+ O                     2.59982   1.16968   0.44752 
+ O                     2.76432   1.07286  -0.76975 
+ 
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ ------------------------------------------------------------------------
+ INPUT DATA FOR L123
+ ------------------------------------------------------------------------
+ GENERAL PARAMETERS:
+ Follow reaction path in both directions.
+ Maximum points per path      =  10
+ Step size                    =   0.100 bohr
+ Integration scheme           = HPC                                 
+    Redo corrector integration= Yes                                 
+    DWI Weight Power          =  2
+    DWI will use Hessian update vectors when possible.
+    Max correction cycles     =  20
+ Initial Hessian              = CalcFC
+ Hessian evaluation           = All updating
+ Hessian updating method      = Bofill                              
+ ------------------------------------------------------------------------
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.605460    1.400000    0.640690
+      2          6           0       -1.845630    0.134550    0.279970
+      3          8           0       -2.618740   -0.713400   -0.557540
+      4          6           0       -0.558060    0.444540   -0.464290
+      5          6           0        0.229160   -0.814860   -0.887560
+      6          6           0        0.691710   -1.641450    0.234460
+      7          8           0        1.729070   -1.314160    0.970380
+      8          1           0       -3.526170    1.162350    1.179210
+      9          1           0       -2.868720    1.953770   -0.262560
+     10          1           0       -2.002380    2.044520    1.282680
+     11          1           0       -1.591940   -0.403210    1.205300
+     12          1           0       -3.456730   -0.890610   -0.128420
+     13          1           0       -0.796650    1.015250   -1.365410
+     14          1           0        0.062680    1.084630    0.165080
+     15          1           0        1.105950   -0.475000   -1.462560
+     16          1           0       -0.407460   -1.419380   -1.532910
+     17          1           0        0.186880   -2.542480    0.557130
+     18          1           0        2.028490   -0.386400    0.817980
+     19          8           0        2.599820    1.169680    0.447520
+     20          8           0        2.764320    1.072860   -0.769750
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519482   0.000000
+     3  O    2.429484   1.420613   0.000000
+     4  C    2.515101   1.519162   2.365570   0.000000
+     5  C    3.908481   2.563057   2.868753   1.544332   0.000000
+     6  C    4.504084   3.097473   3.528118   2.530125   1.468377
+     7  O    5.124794   3.918406   4.647462   3.222153   2.439461
+     8  H    1.092789   2.165461   2.712594   3.467855   4.720530
+     9  H    1.091709   2.156528   2.695051   2.767240   4.201523
+    10  H    1.091450   2.162865   3.372304   2.774509   4.226792
+    11  H    2.144195   1.099900   2.063526   2.138953   2.804625
+    12  H    2.561852   1.952787   0.958006   3.209006   3.764016
+    13  H    2.728418   2.140857   2.638351   1.093002   2.151727
+    14  H    2.728486   2.134830   3.308339   1.091394   2.178033
+    15  H    4.659812   3.481348   3.840470   2.147330   1.102221
+    16  H    4.183855   2.787394   2.517839   2.153794   1.089590
+    17  H    4.831904   3.372596   3.529805   3.243536   2.252463
+    18  H    4.969522   3.945840   4.857544   3.004150   2.515956
+    19  O    5.213953   4.567449   5.638218   3.365922   3.367620
+    20  O    5.561555   4.820164   5.675658   3.395041   3.162974
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.313321   0.000000
+     8  H    5.152122   5.813283   0.000000
+     9  H    5.084220   5.774009   1.771239   0.000000
+    10  H    4.684363   5.030108   1.763765   1.773851   0.000000
+    11  H    2.773234   3.451684   2.488555   3.056163   2.483109
+    12  H    4.231430   5.317826   2.435028   2.907619   3.566697
+    13  H    3.439892   4.154675   3.734569   2.527958   3.086351
+    14  H    2.798572   3.029778   3.730194   3.087294   2.536709
+    15  H    2.100495   2.647955   5.578208   4.810086   4.852426
+    16  H    2.093105   3.292764   4.873118   4.364600   4.740245
+    17  H    1.082046   2.014422   5.281997   5.497713   5.134185
+    18  H    1.924221   0.986720   5.777834   5.534133   4.730035
+    19  O    3.404222   2.683477   6.169536   5.569914   4.758475
+    20  O    3.559723   3.130121   6.586100   5.724018   5.279964
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.343888   0.000000
+    13  H    3.041885   3.498353   0.000000
+    14  H    2.456317   4.046475   1.756605   0.000000
+    15  H    3.794897   4.771867   2.418712   2.483963   0.000000
+    16  H    3.151728   3.398564   2.471224   3.061743   1.785277
+    17  H    2.856712   4.058885   4.161843   3.650350   3.032872
+    18  H    3.641128   5.589055   3.835783   2.540594   2.461665
+    19  O    4.540822   6.423262   3.853125   2.554229   2.930021
+    20  O    5.005657   6.554997   3.610905   2.858829   2.371929
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.445989   0.000000
+    18  H    3.539433   2.847499   0.000000
+    19  O    4.434982   4.428818   1.698542   0.000000
+    20  O    4.105346   4.634058   2.278546   1.232145   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2275424           0.8039475           0.6930522
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.1569105107 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.1445277100 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22618.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7500 S= 0.5000
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Failed to achieve initial convergence to 1.0D-08 in 10 cycles.
+ Switch to full accuracy anyway.
+ Restarting incremental Fock formation.
+ >>>>>>>>>> Convergence criterion not met.
+ SCF Done:  E(UwB97XD) =  -497.907735578     A.U. after   33 cycles
+            NFock= 32  Conv=0.62D-07     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.4113 S= 0.7889
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     1.4113,   after     0.7692
+ SCF Done:  E(UwB97XD) =  -497.907735578     a.u. after    1 cycles
+            Convg  =    0.4523D-06                     1 Fock formations.
+              S**2 =  1.4113                  -V/T =  2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.4113 S= 0.7889
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     1.4113,   after     0.7692
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15995778D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15783959D+02
+
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22618.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+ G2DrvN: will do    21 centers at a time, making    1 passes.
+ Calling FoFCou, ICntrl=  3107 FMM=F I1Cent=   0 AccDes= 0.00D+00.
+ End of G2Drv F.D. properties file   721 does not exist.
+ End of G2Drv F.D. properties file   722 does not exist.
+ End of G2Drv F.D. properties file   788 does not exist.
+          IDoAtm=11111111111111111111
+          Differentiating once with respect to nuclear coordinates.
+ CalDSu exits because no D1Ps are significant.
+          There are    63 degrees of freedom in the 1st order CPHF.  IDoFFX=6 NUNeed=     0.
+     57 vectors produced by pass  0 Test12= 3.57D-14 1.59D-09 XBig12= 1.50D-01 1.78D-01.
+ AX will form    57 AO Fock derivatives at one time.
+     57 vectors produced by pass  1 Test12= 3.57D-14 1.59D-09 XBig12= 1.20D-02 2.50D-02.
+     57 vectors produced by pass  2 Test12= 3.57D-14 1.59D-09 XBig12= 5.54D-04 5.13D-03.
+     57 vectors produced by pass  3 Test12= 3.57D-14 1.59D-09 XBig12= 1.41D-05 5.27D-04.
+     57 vectors produced by pass  4 Test12= 3.57D-14 1.59D-09 XBig12= 2.11D-07 7.35D-05.
+     57 vectors produced by pass  5 Test12= 3.57D-14 1.59D-09 XBig12= 2.70D-09 4.32D-06.
+     57 vectors produced by pass  6 Test12= 3.57D-14 1.59D-09 XBig12= 2.62D-11 4.71D-07.
+     36 vectors produced by pass  7 Test12= 3.57D-14 1.59D-09 XBig12= 2.33D-13 3.93D-08.
+      9 vectors produced by pass  8 Test12= 3.57D-14 1.59D-09 XBig12= 2.35D-15 3.57D-09.
+      1 vectors produced by pass  9 Test12= 3.57D-14 1.59D-09 XBig12= 9.18D-16 1.86D-09.
+ InvSVY:  IOpt=1 It=  1 EMax= 5.83D-16
+ Solved reduced A of dimension   445 with    63 vectors.
+ End of Minotr F.D. properties file   721 does not exist.
+ End of Minotr F.D. properties file   722 does not exist.
+ End of Minotr F.D. properties file   788 does not exist.
+
+ **********************************************************************
+
+            Population analysis using the SCF Density.
+
+ **********************************************************************
+
+ Alpha  occ. eigenvalues --  -19.36227 -19.36136 -19.30421 -19.25605 -10.35755
+ Alpha  occ. eigenvalues --  -10.34302 -10.29733 -10.29179 -10.28212  -1.35238
+ Alpha  occ. eigenvalues --   -1.18733  -1.13603  -0.91274  -0.90862  -0.85532
+ Alpha  occ. eigenvalues --   -0.78310  -0.73759  -0.68918  -0.62938  -0.61674
+ Alpha  occ. eigenvalues --   -0.61130  -0.60095  -0.59346  -0.57856  -0.55205
+ Alpha  occ. eigenvalues --   -0.53455  -0.50553  -0.49121  -0.48258  -0.47094
+ Alpha  occ. eigenvalues --   -0.45011  -0.44457  -0.42547  -0.41060  -0.36937
+ Alpha  occ. eigenvalues --   -0.36840  -0.35812
+ Alpha virt. eigenvalues --    0.02320   0.09711   0.13383   0.14045   0.14341
+ Alpha virt. eigenvalues --    0.15694   0.17803   0.18361   0.18819   0.19589
+ Alpha virt. eigenvalues --    0.20573   0.22598   0.23504   0.24021   0.25590
+ Alpha virt. eigenvalues --    0.26089   0.27798   0.28421   0.30201   0.30823
+ Alpha virt. eigenvalues --    0.32029   0.32727   0.34783   0.36248   0.37618
+ Alpha virt. eigenvalues --    0.39188   0.40168   0.41222   0.42621   0.43793
+ Alpha virt. eigenvalues --    0.45210   0.45950   0.46494   0.47835   0.48328
+ Alpha virt. eigenvalues --    0.49651   0.49971   0.50640   0.51162   0.52399
+ Alpha virt. eigenvalues --    0.52645   0.53711   0.54503   0.55650   0.55922
+ Alpha virt. eigenvalues --    0.56169   0.58423   0.58683   0.59322   0.60896
+ Alpha virt. eigenvalues --    0.61586   0.63143   0.65756   0.66207   0.67096
+ Alpha virt. eigenvalues --    0.68853   0.70863   0.71317   0.74217   0.75722
+ Alpha virt. eigenvalues --    0.77772   0.78696   0.82054   0.84920   0.87245
+ Alpha virt. eigenvalues --    0.87824   0.90722   0.92315   0.93621   0.93931
+ Alpha virt. eigenvalues --    0.95071   0.97423   0.99409   1.02025   1.02871
+ Alpha virt. eigenvalues --    1.06384   1.07848   1.11069   1.12229   1.13708
+ Alpha virt. eigenvalues --    1.18577   1.19398   1.22659   1.23447   1.26224
+ Alpha virt. eigenvalues --    1.27973   1.28435   1.31475   1.32938   1.36832
+ Alpha virt. eigenvalues --    1.37730   1.39287   1.39936   1.41115   1.44921
+ Alpha virt. eigenvalues --    1.46252   1.50409   1.55636   1.58269   1.59236
+ Alpha virt. eigenvalues --    1.61013   1.61208   1.61788   1.64423   1.65796
+ Alpha virt. eigenvalues --    1.65830   1.67091   1.68887   1.69486   1.72319
+ Alpha virt. eigenvalues --    1.73334   1.76147   1.76735   1.79472   1.81178
+ Alpha virt. eigenvalues --    1.82882   1.86786   1.87981   1.88289   1.90229
+ Alpha virt. eigenvalues --    1.93002   1.94052   1.95943   1.97289   1.99026
+ Alpha virt. eigenvalues --    2.01345   2.04348   2.05132   2.07388   2.09674
+ Alpha virt. eigenvalues --    2.11879   2.14183   2.16669   2.18064   2.19214
+ Alpha virt. eigenvalues --    2.21277   2.22111   2.24454   2.25808   2.28474
+ Alpha virt. eigenvalues --    2.29247   2.32566   2.33237   2.36138   2.38796
+ Alpha virt. eigenvalues --    2.40088   2.40449   2.41103   2.43120   2.45152
+ Alpha virt. eigenvalues --    2.46693   2.47577   2.51888   2.53466   2.54840
+ Alpha virt. eigenvalues --    2.57003   2.58582   2.61061   2.62764   2.63427
+ Alpha virt. eigenvalues --    2.65758   2.67090   2.68264   2.68460   2.72498
+ Alpha virt. eigenvalues --    2.73485   2.74138   2.75621   2.79514   2.80521
+ Alpha virt. eigenvalues --    2.82427   2.84017   2.85163   2.86496   2.87868
+ Alpha virt. eigenvalues --    2.88654   2.90376   2.90412   2.93767   2.95127
+ Alpha virt. eigenvalues --    2.98063   3.01626   3.03619   3.04881   3.07647
+ Alpha virt. eigenvalues --    3.09310   3.11062   3.13071   3.13957   3.16757
+ Alpha virt. eigenvalues --    3.18365   3.20335   3.21565   3.23235   3.23871
+ Alpha virt. eigenvalues --    3.27518   3.29225   3.30151   3.30950   3.33897
+ Alpha virt. eigenvalues --    3.36856   3.39456   3.40189   3.43541   3.44594
+ Alpha virt. eigenvalues --    3.48286   3.49684   3.52755   3.53114   3.54681
+ Alpha virt. eigenvalues --    3.55462   3.57998   3.60039   3.62899   3.64441
+ Alpha virt. eigenvalues --    3.67560   3.71953   3.77057   3.78806   3.81923
+ Alpha virt. eigenvalues --    3.85189   3.91576   3.93751   3.95383   3.99505
+ Alpha virt. eigenvalues --    4.02556   4.03659   4.08479   4.10825   4.14202
+ Alpha virt. eigenvalues --    4.18203   4.20678   4.26104   4.30039   4.33472
+ Alpha virt. eigenvalues --    4.35726   4.44900   4.46274   4.47628   4.51126
+ Alpha virt. eigenvalues --    4.54802   4.55580   4.64786   4.67783   4.70553
+ Alpha virt. eigenvalues --    4.72120   4.72577   4.73897   4.74777   4.78146
+ Alpha virt. eigenvalues --    4.83461   4.85110   4.88322   4.99855   5.04170
+ Alpha virt. eigenvalues --    5.04983   5.07530   5.14306   5.24729   5.27356
+ Alpha virt. eigenvalues --    5.31975   5.36979   5.42493   5.47627   5.57413
+ Alpha virt. eigenvalues --    5.57779   5.74356   5.74983   5.86671   5.87869
+ Alpha virt. eigenvalues --    5.92360   5.95691   6.00662   6.21506   6.21860
+ Alpha virt. eigenvalues --    6.25704   6.33419   6.35029   6.37009   6.38798
+ Alpha virt. eigenvalues --    6.39361   6.45468   6.46738   6.47388   6.52093
+ Alpha virt. eigenvalues --    6.58154   6.70998   6.80111   6.80553   6.83770
+ Alpha virt. eigenvalues --    6.88221   7.05253   7.07756   7.24697   7.25615
+ Alpha virt. eigenvalues --    7.27133   7.29231   7.53062   8.76187  22.43630
+ Alpha virt. eigenvalues --   22.58266  22.61898  22.65441  22.75220  43.40587
+ Alpha virt. eigenvalues --   43.75719  43.92103  44.04915
+  Beta  occ. eigenvalues --  -19.34004 -19.33819 -19.30624 -19.25607 -10.36506
+  Beta  occ. eigenvalues --  -10.34307 -10.29657 -10.29255 -10.28212  -1.30126
+  Beta  occ. eigenvalues --   -1.19415  -1.13610  -0.91464  -0.85998  -0.83313
+  Beta  occ. eigenvalues --   -0.79134  -0.74043  -0.68975  -0.62744  -0.60471
+  Beta  occ. eigenvalues --   -0.58971  -0.56905  -0.55813  -0.54207  -0.53085
+  Beta  occ. eigenvalues --   -0.51668  -0.51158  -0.49112  -0.48807  -0.47071
+  Beta  occ. eigenvalues --   -0.45077  -0.44500  -0.42874  -0.41156  -0.36921
+  Beta  occ. eigenvalues --   -0.22616
+  Beta virt. eigenvalues --   -0.06140  -0.01628   0.09661   0.13334   0.14085
+  Beta virt. eigenvalues --    0.14462   0.15567   0.17743   0.18676   0.18789
+  Beta virt. eigenvalues --    0.19560   0.20591   0.22659   0.23491   0.24012
+  Beta virt. eigenvalues --    0.25771   0.26849   0.28063   0.28457   0.30176
+  Beta virt. eigenvalues --    0.30670   0.32229   0.33382   0.34704   0.36191
+  Beta virt. eigenvalues --    0.37775   0.39112   0.40316   0.41155   0.42395
+  Beta virt. eigenvalues --    0.43868   0.45190   0.46106   0.46337   0.47902
+  Beta virt. eigenvalues --    0.48312   0.49749   0.50047   0.50619   0.51041
+  Beta virt. eigenvalues --    0.52432   0.53273   0.53943   0.54517   0.55726
+  Beta virt. eigenvalues --    0.55942   0.56694   0.58704   0.58865   0.59615
+  Beta virt. eigenvalues --    0.61107   0.61672   0.63598   0.66054   0.66202
+  Beta virt. eigenvalues --    0.67117   0.69075   0.71219   0.71985   0.74614
+  Beta virt. eigenvalues --    0.75895   0.77938   0.78648   0.82053   0.85000
+  Beta virt. eigenvalues --    0.87196   0.87996   0.90901   0.92381   0.93172
+  Beta virt. eigenvalues --    0.93813   0.95052   0.97487   0.99181   1.01719
+  Beta virt. eigenvalues --    1.02605   1.05946   1.07725   1.10953   1.11972
+  Beta virt. eigenvalues --    1.13381   1.18585   1.19141   1.22665   1.23371
+  Beta virt. eigenvalues --    1.26297   1.28031   1.28504   1.31489   1.32893
+  Beta virt. eigenvalues --    1.36706   1.39105   1.40110   1.42115   1.42460
+  Beta virt. eigenvalues --    1.44958   1.46800   1.50438   1.54952   1.58262
+  Beta virt. eigenvalues --    1.59124   1.60577   1.61137   1.61608   1.64543
+  Beta virt. eigenvalues --    1.65829   1.66763   1.67073   1.69264   1.71240
+  Beta virt. eigenvalues --    1.72546   1.73876   1.76454   1.77501   1.79925
+  Beta virt. eigenvalues --    1.81332   1.82974   1.86705   1.87947   1.88270
+  Beta virt. eigenvalues --    1.89579   1.92989   1.94136   1.95797   1.97240
+  Beta virt. eigenvalues --    1.99300   2.02413   2.04264   2.05367   2.07486
+  Beta virt. eigenvalues --    2.09628   2.11974   2.14355   2.17185   2.18230
+  Beta virt. eigenvalues --    2.19533   2.22002   2.22487   2.26110   2.27222
+  Beta virt. eigenvalues --    2.28965   2.29695   2.32614   2.33211   2.35804
+  Beta virt. eigenvalues --    2.38914   2.40014   2.40421   2.41098   2.43082
+  Beta virt. eigenvalues --    2.45361   2.46629   2.47646   2.52441   2.53569
+  Beta virt. eigenvalues --    2.55132   2.57301   2.60506   2.62470   2.63622
+  Beta virt. eigenvalues --    2.64618   2.66360   2.67402   2.68492   2.68802
+  Beta virt. eigenvalues --    2.72785   2.73262   2.73841   2.76452   2.79767
+  Beta virt. eigenvalues --    2.80456   2.82494   2.84520   2.85365   2.87763
+  Beta virt. eigenvalues --    2.88586   2.89565   2.90400   2.92373   2.94349
+  Beta virt. eigenvalues --    2.95335   2.98856   3.02039   3.03280   3.04977
+  Beta virt. eigenvalues --    3.07437   3.08817   3.11496   3.12225   3.14114
+  Beta virt. eigenvalues --    3.15958   3.18444   3.20385   3.21928   3.22629
+  Beta virt. eigenvalues --    3.23669   3.26876   3.29116   3.29964   3.30525
+  Beta virt. eigenvalues --    3.33618   3.36489   3.39093   3.40061   3.43312
+  Beta virt. eigenvalues --    3.44259   3.47689   3.49071   3.52327   3.52792
+  Beta virt. eigenvalues --    3.53723   3.55287   3.57570   3.59789   3.62815
+  Beta virt. eigenvalues --    3.64263   3.66748   3.71823   3.76878   3.78568
+  Beta virt. eigenvalues --    3.81484   3.84725   3.91273   3.93348   3.95134
+  Beta virt. eigenvalues --    3.99348   4.02169   4.03477   4.08212   4.10628
+  Beta virt. eigenvalues --    4.14031   4.17849   4.20503   4.25788   4.29847
+  Beta virt. eigenvalues --    4.33730   4.37550   4.44773   4.46260   4.47267
+  Beta virt. eigenvalues --    4.50499   4.54540   4.55338   4.64730   4.67813
+  Beta virt. eigenvalues --    4.73191   4.73617   4.75838   4.75850   4.76617
+  Beta virt. eigenvalues --    4.79063   4.83396   4.84677   4.88113   4.99779
+  Beta virt. eigenvalues --    5.08422   5.10108   5.12460   5.14383   5.29598
+  Beta virt. eigenvalues --    5.31999   5.33261   5.36978   5.42329   5.47622
+  Beta virt. eigenvalues --    5.57054   5.57777   5.78830   5.79313   5.86660
+  Beta virt. eigenvalues --    5.87839   5.91369   5.95198   6.00654   6.23579
+  Beta virt. eigenvalues --    6.27094   6.31991   6.38394   6.39349   6.41052
+  Beta virt. eigenvalues --    6.41623   6.45104   6.48984   6.51465   6.52130
+  Beta virt. eigenvalues --    6.54530   6.58245   6.73681   6.79888   6.80551
+  Beta virt. eigenvalues --    6.84004   6.88217   7.05067   7.07752   7.26345
+  Beta virt. eigenvalues --    7.27071   7.28469   7.31177   7.55947   8.79141
+  Beta virt. eigenvalues --   22.43628  22.58171  22.61854  22.65305  22.74181
+  Beta virt. eigenvalues --   43.42918  43.77790  43.92043  44.04916
+          Condensed to atoms (all electrons):
+               1          2          3          4          5          6
+     1  C    4.939034   0.322363  -0.024055  -0.064193   0.010221   0.002094
+     2  C    0.322363   4.917459   0.278387   0.199463  -0.026377   0.038431
+     3  O   -0.024055   0.278387   8.037163  -0.083047  -0.001925   0.001651
+     4  C   -0.064193   0.199463  -0.083047   5.341804   0.253392  -0.111491
+     5  C    0.010221  -0.026377  -0.001925   0.253392   5.016038   0.358297
+     6  C    0.002094   0.038431   0.001651  -0.111491   0.358297   5.090693
+     7  O   -0.000059  -0.009411   0.000072   0.015545  -0.064693   0.311009
+     8  H    0.410719  -0.043247  -0.003709   0.014403  -0.000711   0.000211
+     9  H    0.410985  -0.033915   0.000773  -0.009976  -0.000074  -0.000238
+    10  H    0.408132  -0.041228   0.006029  -0.004241   0.000054  -0.000017
+    11  H   -0.042056   0.403850  -0.052582  -0.051401  -0.008235  -0.007477
+    12  H   -0.004387  -0.033316   0.297392   0.016316  -0.001599   0.000533
+    13  H   -0.008649  -0.020323   0.004164   0.401528  -0.033627   0.005593
+    14  H    0.001421  -0.037569   0.003824   0.399543  -0.027269  -0.002285
+    15  H    0.000056   0.015726   0.000178  -0.100946   0.401164  -0.034211
+    16  H    0.000398  -0.007062   0.009603  -0.033326   0.397087  -0.025524
+    17  H    0.000383   0.003539   0.002313  -0.005985  -0.055776   0.420844
+    18  H   -0.000052  -0.002483   0.000033   0.013101   0.004757  -0.046181
+    19  O   -0.000001  -0.002009   0.000001   0.003501   0.013910  -0.010170
+    20  O   -0.000031   0.001652  -0.000001  -0.017003   0.001181   0.002051
+               7          8          9         10         11         12
+     1  C   -0.000059   0.410719   0.410985   0.408132  -0.042056  -0.004387
+     2  C   -0.009411  -0.043247  -0.033915  -0.041228   0.403850  -0.033316
+     3  O    0.000072  -0.003709   0.000773   0.006029  -0.052582   0.297392
+     4  C    0.015545   0.014403  -0.009976  -0.004241  -0.051401   0.016316
+     5  C   -0.064693  -0.000711  -0.000074   0.000054  -0.008235  -0.001599
+     6  C    0.311009   0.000211  -0.000238  -0.000017  -0.007477   0.000533
+     7  O    7.856881   0.000001   0.000002  -0.000032   0.002912   0.000001
+     8  H    0.000001   0.562395  -0.027048  -0.020304  -0.009222   0.004293
+     9  H    0.000002  -0.027048   0.543457  -0.021664   0.009233  -0.001512
+    10  H   -0.000032  -0.020304  -0.021664   0.552717   0.000228   0.000379
+    11  H    0.002912  -0.009222   0.009233   0.000228   0.679060  -0.007819
+    12  H    0.000001   0.004293  -0.001512   0.000379  -0.007819   0.419868
+    13  H   -0.000002  -0.000169   0.004566   0.001028   0.008693  -0.000362
+    14  H   -0.000509  -0.000328   0.000499   0.000887   0.001445  -0.000648
+    15  H    0.003488   0.000018  -0.000052  -0.000006  -0.000751   0.000020
+    16  H    0.004158  -0.000008   0.000078  -0.000084   0.000880  -0.000737
+    17  H   -0.036000  -0.000008  -0.000008  -0.000031  -0.003663  -0.000094
+    18  H    0.283403  -0.000001   0.000004  -0.000038   0.000164   0.000001
+    19  O   -0.037902  -0.000000   0.000006  -0.000037   0.000313  -0.000000
+    20  O    0.007862   0.000000  -0.000003   0.000011  -0.000089   0.000000
+              13         14         15         16         17         18
+     1  C   -0.008649   0.001421   0.000056   0.000398   0.000383  -0.000052
+     2  C   -0.020323  -0.037569   0.015726  -0.007062   0.003539  -0.002483
+     3  O    0.004164   0.003824   0.000178   0.009603   0.002313   0.000033
+     4  C    0.401528   0.399543  -0.100946  -0.033326  -0.005985   0.013101
+     5  C   -0.033627  -0.027269   0.401164   0.397087  -0.055776   0.004757
+     6  C    0.005593  -0.002285  -0.034211  -0.025524   0.420844  -0.046181
+     7  O   -0.000002  -0.000509   0.003488   0.004158  -0.036000   0.283403
+     8  H   -0.000169  -0.000328   0.000018  -0.000008  -0.000008  -0.000001
+     9  H    0.004566   0.000499  -0.000052   0.000078  -0.000008   0.000004
+    10  H    0.001028   0.000887  -0.000006  -0.000084  -0.000031  -0.000038
+    11  H    0.008693   0.001445  -0.000751   0.000880  -0.003663   0.000164
+    12  H   -0.000362  -0.000648   0.000020  -0.000737  -0.000094   0.000001
+    13  H    0.553363  -0.018774  -0.004469  -0.003365  -0.000447  -0.000071
+    14  H   -0.018774   0.547822   0.000115   0.004983   0.000717  -0.001549
+    15  H   -0.004469   0.000115   0.567156  -0.005798   0.004813  -0.008165
+    16  H   -0.003365   0.004983  -0.005798   0.521102   0.000972  -0.000404
+    17  H   -0.000447   0.000717   0.004813   0.000972   0.512999   0.003070
+    18  H   -0.000071  -0.001549  -0.008165  -0.000404   0.003070   0.369906
+    19  O    0.000532   0.006070  -0.015601  -0.000170  -0.000364   0.070024
+    20  O   -0.000192  -0.001104   0.027515   0.001218   0.000167  -0.019353
+              19         20
+     1  C   -0.000001  -0.000031
+     2  C   -0.002009   0.001652
+     3  O    0.000001  -0.000001
+     4  C    0.003501  -0.017003
+     5  C    0.013910   0.001181
+     6  C   -0.010170   0.002051
+     7  O   -0.037902   0.007862
+     8  H   -0.000000   0.000000
+     9  H    0.000006  -0.000003
+    10  H   -0.000037   0.000011
+    11  H    0.000313  -0.000089
+    12  H   -0.000000   0.000000
+    13  H    0.000532  -0.000192
+    14  H    0.006070  -0.001104
+    15  H   -0.015601   0.027515
+    16  H   -0.000170   0.001218
+    17  H   -0.000364   0.000167
+    18  H    0.070024  -0.019353
+    19  O    8.098047   0.029951
+    20  O    0.029951   8.054057
+          Atomic-Atomic Spin Densities.
+               1          2          3          4          5          6
+     1  C   -0.001762  -0.000121  -0.000219   0.002714   0.000536  -0.001982
+     2  C   -0.000121  -0.012514   0.002126   0.046416  -0.000492  -0.036566
+     3  O   -0.000219   0.002126  -0.001523  -0.003414   0.000649   0.000854
+     4  C    0.002714   0.046416  -0.003414  -0.205470  -0.018079   0.108183
+     5  C    0.000536  -0.000492   0.000649  -0.018079   0.049968  -0.019403
+     6  C   -0.001982  -0.036566   0.000854   0.108183  -0.019403  -0.783573
+     7  O    0.000064   0.002615  -0.000009  -0.007644   0.004871   0.116595
+     8  H   -0.000911   0.000743  -0.000015   0.000419  -0.000061  -0.000112
+     9  H    0.001002  -0.000713  -0.000008  -0.000299   0.000052   0.000151
+    10  H   -0.000223  -0.000113   0.000012   0.000622  -0.000066  -0.000250
+    11  H    0.002269   0.001225  -0.000510  -0.009255  -0.000257   0.010007
+    12  H   -0.000092  -0.000143   0.000122   0.000296  -0.000077  -0.000066
+    13  H   -0.000101  -0.001061  -0.000010   0.000936  -0.000627   0.000265
+    14  H   -0.000464  -0.004274   0.000033   0.010537  -0.000160  -0.006681
+    15  H   -0.000236  -0.007676   0.000242   0.053286   0.023354   0.003469
+    16  H   -0.000182  -0.004779   0.000639   0.019705  -0.000259  -0.000706
+    17  H   -0.000066  -0.002444   0.000123   0.006304   0.000651  -0.001452
+    18  H    0.000046   0.002382  -0.000011  -0.014268  -0.004098   0.017570
+    19  O    0.000076   0.000294  -0.000002  -0.011900  -0.003139   0.012041
+    20  O   -0.000017  -0.000525   0.000002   0.014508   0.000625  -0.005147
+               7          8          9         10         11         12
+     1  C    0.000064  -0.000911   0.001002  -0.000223   0.002269  -0.000092
+     2  C    0.002615   0.000743  -0.000713  -0.000113   0.001225  -0.000143
+     3  O   -0.000009  -0.000015  -0.000008   0.000012  -0.000510   0.000122
+     4  C   -0.007644   0.000419  -0.000299   0.000622  -0.009255   0.000296
+     5  C    0.004871  -0.000061   0.000052  -0.000066  -0.000257  -0.000077
+     6  C    0.116595  -0.000112   0.000151  -0.000250   0.010007  -0.000066
+     7  O   -0.163250   0.000003  -0.000003   0.000018  -0.000841   0.000001
+     8  H    0.000003  -0.000694   0.000259  -0.000134   0.000186  -0.000019
+     9  H   -0.000003   0.000259  -0.000930   0.000112  -0.000116   0.000009
+    10  H    0.000018  -0.000134   0.000112  -0.000142   0.000186  -0.000005
+    11  H   -0.000841   0.000186  -0.000116   0.000186  -0.001439   0.000018
+    12  H    0.000001  -0.000019   0.000009  -0.000005   0.000018  -0.000045
+    13  H   -0.000034  -0.000004   0.000063  -0.000024   0.000107  -0.000005
+    14  H    0.001157  -0.000039   0.000109  -0.000139   0.000569  -0.000004
+    15  H   -0.007730  -0.000010   0.000046  -0.000034   0.000611  -0.000008
+    16  H   -0.000040  -0.000011   0.000027  -0.000011   0.000426  -0.000024
+    17  H    0.000321  -0.000005   0.000003  -0.000006   0.000444  -0.000006
+    18  H    0.006713   0.000003  -0.000006   0.000023  -0.000441   0.000001
+    19  O   -0.006480   0.000001  -0.000002   0.000002  -0.000029   0.000000
+    20  O   -0.000550  -0.000000   0.000001  -0.000002   0.000016  -0.000000
+              13         14         15         16         17         18
+     1  C   -0.000101  -0.000464  -0.000236  -0.000182  -0.000066   0.000046
+     2  C   -0.001061  -0.004274  -0.007676  -0.004779  -0.002444   0.002382
+     3  O   -0.000010   0.000033   0.000242   0.000639   0.000123  -0.000011
+     4  C    0.000936   0.010537   0.053286   0.019705   0.006304  -0.014268
+     5  C   -0.000627  -0.000160   0.023354  -0.000259   0.000651  -0.004098
+     6  C    0.000265  -0.006681   0.003469  -0.000706  -0.001452   0.017570
+     7  O   -0.000034   0.001157  -0.007730  -0.000040   0.000321   0.006713
+     8  H   -0.000004  -0.000039  -0.000010  -0.000011  -0.000005   0.000003
+     9  H    0.000063   0.000109   0.000046   0.000027   0.000003  -0.000006
+    10  H   -0.000024  -0.000139  -0.000034  -0.000011  -0.000006   0.000023
+    11  H    0.000107   0.000569   0.000611   0.000426   0.000444  -0.000441
+    12  H   -0.000005  -0.000004  -0.000008  -0.000024  -0.000006   0.000001
+    13  H    0.002025  -0.000047  -0.000441  -0.000381  -0.000006  -0.000001
+    14  H   -0.000047   0.000187  -0.002363  -0.000350  -0.000047   0.000961
+    15  H   -0.000441  -0.002363  -0.083840  -0.009573  -0.002210   0.008835
+    16  H   -0.000381  -0.000350  -0.009573  -0.010636  -0.001637   0.000606
+    17  H   -0.000006  -0.000047  -0.002210  -0.001637   0.018020   0.001689
+    18  H   -0.000001   0.000961   0.008835   0.000606   0.001689  -0.029889
+    19  O    0.000267   0.004454   0.006901   0.000060   0.000231  -0.008720
+    20  O   -0.000511  -0.003637  -0.018196  -0.000265  -0.000186   0.004780
+              19         20
+     1  C    0.000076  -0.000017
+     2  C    0.000294  -0.000525
+     3  O   -0.000002   0.000002
+     4  C   -0.011900   0.014508
+     5  C   -0.003139   0.000625
+     6  C    0.012041  -0.005147
+     7  O   -0.006480  -0.000550
+     8  H    0.000001  -0.000000
+     9  H   -0.000002   0.000001
+    10  H    0.000002  -0.000002
+    11  H   -0.000029   0.000016
+    12  H    0.000000  -0.000000
+    13  H    0.000267  -0.000511
+    14  H    0.004454  -0.003637
+    15  H    0.006901  -0.018196
+    16  H    0.000060  -0.000265
+    17  H    0.000231  -0.000186
+    18  H   -0.008720   0.004780
+    19  O    1.080170  -0.295545
+    20  O   -0.295545   1.190171
+ Mulliken charges and spin densities:
+               1          2
+     1  C   -0.362322   0.000332
+     2  C    0.076069  -0.015620
+     3  O   -0.476264  -0.000921
+     4  C   -0.176987  -0.006405
+     5  C   -0.235815   0.033988
+     6  C    0.006188  -0.586805
+     7  O   -0.336724  -0.054226
+     8  H    0.112715  -0.000401
+     9  H    0.124887  -0.000242
+    10  H    0.118219  -0.000174
+    11  H    0.076519   0.003176
+    12  H    0.311669  -0.000048
+    13  H    0.110984   0.000410
+    14  H    0.122708  -0.000198
+    15  H    0.149749  -0.035574
+    16  H    0.136000  -0.007391
+    17  H    0.152559   0.019720
+    18  H    0.333835  -0.013827
+    19  O   -0.156102   0.778679
+    20  O   -0.087888   0.885523
+ Sum of Mulliken charges =  -0.00000   1.00000
+ Mulliken charges and spin densities with hydrogens summed into heavy atoms:
+               1          2
+     1  C   -0.006501  -0.000484
+     2  C    0.152588  -0.012444
+     3  O   -0.164595  -0.000969
+     4  C    0.056705  -0.006192
+     5  C    0.049935  -0.008977
+     6  C    0.158747  -0.567085
+     7  O   -0.002889  -0.068052
+    19  O   -0.156102   0.778679
+    20  O   -0.087888   0.885523
+ APT charges:
+               1
+     1  C   -1.309894
+     2  C   -0.051023
+     3  O   -1.050845
+     4  C   -0.412021
+     5  C   -0.818076
+     6  C   -0.348260
+     7  O   -0.285955
+     8  H    0.584627
+     9  H    0.396043
+    10  H    0.230805
+    11  H    0.218668
+    12  H    0.903428
+    13  H    0.364302
+    14  H    0.211249
+    15  H    0.329393
+    16  H    0.414017
+    17  H    0.509076
+    18  H    0.345845
+    19  O   -0.139844
+    20  O   -0.091533
+ Sum of APT charges =  -0.00000
+ APT charges with hydrogens summed into heavy atoms:
+               1
+     1  C   -0.098419
+     2  C    0.167644
+     3  O   -0.147417
+     4  C    0.163530
+     5  C   -0.074666
+     6  C    0.160816
+     7  O    0.059889
+    19  O   -0.139844
+    20  O   -0.091533
+ Electronic spatial extent (au):  <R**2>=           1680.2007
+ Charge=             -0.0000 electrons
+ Dipole moment (field-independent basis, Debye):
+    X=             -3.0264    Y=             -0.5192    Z=              0.8114  Tot=              3.1761
+ Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=            -55.5481   YY=            -54.9997   ZZ=            -56.4768
+   XY=             -0.8225   XZ=             -3.9541   YZ=              0.2925
+ Traceless Quadrupole moment (field-independent basis, Debye-Ang):
+   XX=              0.1267   YY=              0.6752   ZZ=             -0.8019
+   XY=             -0.8225   XZ=             -3.9541   YZ=              0.2925
+ Octapole moment (field-independent basis, Debye-Ang**2):
+  XXX=            -27.6301  YYY=             -4.6958  ZZZ=             -1.1370  XYY=             -3.6061
+  XXY=             -8.0575  XXZ=             10.7890  XZZ=              4.3534  YZZ=              2.5114
+  YYZ=             -0.0737  XYZ=              6.0978
+ Hexadecapole moment (field-independent basis, Debye-Ang**3):
+ XXXX=          -1255.8344 YYYY=           -457.4228 ZZZZ=           -221.4516 XXXY=             44.5256
+ XXXZ=            -16.0241 YYYX=             29.6968 YYYZ=             -8.4755 ZZZX=              4.4632
+ ZZZY=             -1.7421 XXYY=           -320.5113 XXZZ=           -277.2401 YYZZ=           -116.4264
+ XXYZ=             -2.2775 YYXZ=             -1.4351 ZZXY=              8.0747
+ N-N= 4.741445277100D+02 E-N=-2.116116576042D+03  KE= 4.958043004682D+02
+  Exact polarizability:       0.000       0.000       0.000       0.000       0.000       0.000
+ Approx polarizability:     113.776      46.005     137.812      -5.785     -10.339      90.665
+                          Isotropic Fermi Contact Couplings
+        Atom                 a.u.       MegaHertz       Gauss      10(-4) cm-1
+     1  C(13)              0.00002       0.02202       0.00786       0.00734
+     2  C(13)             -0.00241      -2.71093      -0.96733      -0.90427
+     3  O(17)             -0.00027       0.16552       0.05906       0.05521
+     4  C(13)             -0.03685     -41.43065     -14.78349     -13.81978
+     5  C(13)              0.02231      25.08496       8.95094       8.36744
+     6  C(13)             -0.04571     -51.39083     -18.33753     -17.14214
+     7  O(17)             -0.03725      22.57968       8.05699       7.53177
+     8  H(1)              -0.00015      -0.68086      -0.24295      -0.22711
+     9  H(1)              -0.00025      -1.09700      -0.39144      -0.36592
+    10  H(1)              -0.00000      -0.01982      -0.00707      -0.00661
+    11  H(1)              -0.00008      -0.35690      -0.12735      -0.11905
+    12  H(1)               0.00002       0.07754       0.02767       0.02586
+    13  H(1)               0.00024       1.05439       0.37623       0.35171
+    14  H(1)               0.00063       2.79698       0.99803       0.93297
+    15  H(1)              -0.00640     -28.61322     -10.20991      -9.54434
+    16  H(1)              -0.00282     -12.59980      -4.49592      -4.20284
+    17  H(1)               0.00975      43.57397      15.54828      14.53471
+    18  H(1)              -0.00406     -18.16513      -6.48177      -6.05923
+    19  O(17)              0.11030     -66.86239     -23.85816     -22.30289
+    20  O(17)              0.12048     -73.03200     -26.05963     -24.36085
+ --------------------------------------------------------
+       Center         ----  Spin Dipole Couplings  ----
+                      3XX-RR        3YY-RR        3ZZ-RR
+ --------------------------------------------------------
+     1   Atom        0.002347     -0.002028     -0.000320
+     2   Atom        0.003911     -0.001873     -0.002038
+     3   Atom        0.000022      0.000509     -0.000531
+     4   Atom        0.023218     -0.037043      0.013825
+     5   Atom        0.017890     -0.010667     -0.007223
+     6   Atom       -0.048992      0.078745     -0.029753
+     7   Atom       -0.154100      0.334745     -0.180645
+     8   Atom        0.000945     -0.000784     -0.000161
+     9   Atom        0.002130     -0.001545     -0.000586
+    10   Atom        0.003325     -0.002572     -0.000753
+    11   Atom       -0.001415      0.000258      0.001157
+    12   Atom       -0.000966      0.000592      0.000375
+    13   Atom        0.010527     -0.006814     -0.003713
+    14   Atom        0.025761     -0.019404     -0.006357
+    15   Atom        0.011539      0.000438     -0.011977
+    16   Atom        0.002951      0.006998     -0.009949
+    17   Atom        0.009480     -0.031820      0.022340
+    18   Atom       -0.015436      0.025846     -0.010410
+    19   Atom        1.213255      0.679223     -1.892478
+    20   Atom        1.275235      0.844448     -2.119683
+ --------------------------------------------------------
+                        XY            XZ            YZ
+ --------------------------------------------------------
+     1   Atom        0.001306     -0.000443      0.000220
+     2   Atom        0.007222     -0.002469      0.003588
+     3   Atom        0.002340     -0.001818     -0.001675
+     4   Atom        0.031404      0.009193     -0.013014
+     5   Atom        0.011591     -0.009142      0.009847
+     6   Atom        0.367065      0.419197     -0.345427
+     7   Atom        0.072901      0.370396     -0.081945
+     8   Atom        0.001001     -0.000166     -0.000228
+     9   Atom        0.000655     -0.000064      0.000166
+    10   Atom        0.000345     -0.001014     -0.000324
+    11   Atom        0.008261      0.001686     -0.001416
+    12   Atom        0.001182     -0.000338      0.000050
+    13   Atom        0.003747      0.001944      0.003888
+    14   Atom        0.002519     -0.003873     -0.000782
+    15   Atom        0.017465      0.008989      0.018202
+    16   Atom        0.007587     -0.005603      0.004910
+    17   Atom       -0.015242      0.030232      0.008273
+    18   Atom        0.023531     -0.011384     -0.035779
+    19   Atom       -0.467700      0.476260     -0.233182
+    20   Atom       -0.476502      0.510360     -0.289977
+ --------------------------------------------------------
+
+
+ ---------------------------------------------------------------------------------
+              Anisotropic Spin Dipole Couplings in Principal Axis System
+ ---------------------------------------------------------------------------------
+
+       Atom             a.u.   MegaHertz   Gauss  10(-4) cm-1        Axes
+
+              Baa    -0.0024    -0.327    -0.117    -0.109 -0.2734  0.9492 -0.1556
+     1 C(13)  Bbb    -0.0003    -0.042    -0.015    -0.014  0.0740  0.1821  0.9805
+              Bcc     0.0028     0.369     0.132     0.123  0.9591  0.2565 -0.1200
+ 
+              Baa    -0.0094    -1.255    -0.448    -0.419 -0.4824  0.7111 -0.5115
+     2 C(13)  Bbb     0.0006     0.075     0.027     0.025 -0.2838  0.4256  0.8592
+              Bcc     0.0088     1.181     0.421     0.394  0.8287  0.5596 -0.0036
+ 
+              Baa    -0.0022     0.160     0.057     0.053  0.7928 -0.3977  0.4618
+     3 O(17)  Bbb    -0.0018     0.127     0.045     0.042 -0.1040  0.6583  0.7455
+              Bcc     0.0040    -0.287    -0.102    -0.096  0.6005  0.6391 -0.4806
+ 
+              Baa    -0.0540    -7.248    -2.586    -2.418 -0.3899  0.8932  0.2242
+     4 C(13)  Bbb     0.0169     2.263     0.807     0.755 -0.0628 -0.2687  0.9612
+              Bcc     0.0372     4.986     1.779     1.663  0.9187  0.3606  0.1608
+ 
+              Baa    -0.0241    -3.237    -1.155    -1.080 -0.3314  0.7262 -0.6024
+     5 C(13)  Bbb     0.0010     0.140     0.050     0.047 -0.0165  0.6339  0.7733
+              Bcc     0.0231     3.097     1.105     1.033  0.9433  0.2662 -0.1981
+ 
+              Baa    -0.7611  -102.133   -36.444   -34.068  0.6162 -0.5146 -0.5962
+     6 C(13)  Bbb     0.3724    49.968    17.830    16.668  0.2594 -0.5822  0.7705
+              Bcc     0.3887    52.165    18.614    17.400  0.7436  0.6295  0.2253
+ 
+              Baa    -0.5516    39.910    14.241    13.313 -0.6886  0.1227  0.7147
+     7 O(17)  Bbb     0.2031   -14.698    -5.245    -4.903  0.7224  0.0300  0.6908
+              Bcc     0.3484   -25.212    -8.996    -8.410  0.0633  0.9920 -0.1093
+ 
+              Baa    -0.0013    -0.672    -0.240    -0.224 -0.4018  0.9067  0.1280
+     8 H(1)   Bbb    -0.0002    -0.097    -0.034    -0.032  0.1916 -0.0534  0.9800
+              Bcc     0.0014     0.769     0.274     0.256  0.8955  0.4183 -0.1522
+ 
+              Baa    -0.0017    -0.899    -0.321    -0.300 -0.1695  0.9729 -0.1572
+     9 H(1)   Bbb    -0.0006    -0.298    -0.106    -0.099 -0.0145  0.1570  0.9875
+              Bcc     0.0022     1.197     0.427     0.399  0.9854  0.1697 -0.0125
+ 
+              Baa    -0.0026    -1.405    -0.501    -0.469 -0.0310  0.9877  0.1533
+    10 H(1)   Bbb    -0.0010    -0.511    -0.182    -0.170  0.2390 -0.1416  0.9606
+              Bcc     0.0036     1.916     0.684     0.639  0.9705  0.0665 -0.2316
+ 
+              Baa    -0.0093    -4.985    -1.779    -1.663  0.7267 -0.6556 -0.2051
+    11 H(1)   Bbb     0.0016     0.863     0.308     0.288  0.1436 -0.1470  0.9787
+              Bcc     0.0077     4.122     1.471     1.375  0.6717  0.7407  0.0127
+ 
+              Baa    -0.0017    -0.883    -0.315    -0.294  0.8725 -0.4628  0.1569
+    12 H(1)   Bbb     0.0004     0.219     0.078     0.073 -0.0718  0.1961  0.9780
+              Bcc     0.0012     0.664     0.237     0.222  0.4834  0.8645 -0.1379
+ 
+              Baa    -0.0097    -5.158    -1.841    -1.721 -0.1074  0.8481 -0.5188
+    13 H(1)   Bbb    -0.0021    -1.132    -0.404    -0.377 -0.2700  0.4773  0.8363
+              Bcc     0.0118     6.290     2.244     2.098  0.9569  0.2299  0.1777
+ 
+              Baa    -0.0196   -10.441    -3.726    -3.483 -0.0517  0.9977  0.0439
+    14 H(1)   Bbb    -0.0068    -3.628    -1.294    -1.210  0.1209 -0.0374  0.9920
+              Bcc     0.0264    14.069     5.020     4.693  0.9913  0.0566 -0.1187
+ 
+              Baa    -0.0253   -13.500    -4.817    -4.503  0.1045 -0.6205  0.7772
+    15 H(1)   Bbb    -0.0067    -3.588    -1.280    -1.197  0.7159 -0.4955 -0.4919
+              Bcc     0.0320    17.088     6.097     5.700  0.6903  0.6078  0.3924
+ 
+              Baa    -0.0147    -7.817    -2.789    -2.608  0.4143 -0.3370  0.8454
+    16 H(1)   Bbb     0.0018     0.968     0.345     0.323  0.6847 -0.4966 -0.5335
+              Bcc     0.0128     6.850     2.444     2.285  0.5996  0.7999  0.0249
+ 
+              Baa    -0.0425   -22.678    -8.092    -7.565  0.4282  0.8495 -0.3080
+    17 H(1)   Bbb    -0.0044    -2.374    -0.847    -0.792  0.6402 -0.5258 -0.5601
+              Bcc     0.0470    25.052     8.939     8.356  0.6378 -0.0426  0.7690
+ 
+              Baa    -0.0331   -17.674    -6.307    -5.896 -0.2691  0.5758  0.7721
+    18 H(1)   Bbb    -0.0240   -12.821    -4.575    -4.277  0.9020 -0.1303  0.4116
+              Bcc     0.0572    30.496    10.882    10.172  0.3376  0.8071 -0.4843
+ 
+              Baa    -1.9740   142.834    50.967    47.644 -0.1385  0.0624  0.9884
+    19 O(17)  Bbb     0.4082   -29.539   -10.540    -9.853  0.4958  0.8683  0.0146
+              Bcc     1.5657  -113.295   -40.426   -37.791  0.8573 -0.4921  0.1512
+ 
+              Baa    -2.2106   159.959    57.077    53.357 -0.1347  0.0728  0.9882
+    20 O(17)  Bbb     0.5373   -38.878   -13.872   -12.968  0.5370  0.8435  0.0111
+              Bcc     1.6733  -121.082   -43.205   -40.388  0.8328 -0.5322  0.1527
+ 
+
+ ---------------------------------------------------------------------------------
+
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22618.
+ LDataN:  DoStor=T MaxTD1= 8 Len=  415
+ Calling FoFJK, ICntrl=    100127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000000276    0.000006316   -0.000003266
+      2        6          -0.000003395   -0.000003197   -0.000003506
+      3        8           0.000002549    0.000000236    0.000001141
+      4        6           0.000003654    0.000006678   -0.000008667
+      5        6          -0.000009671   -0.000002378   -0.000003020
+      6        6          -0.000009003   -0.000017852   -0.000016026
+      7        8           0.000008325   -0.000012854    0.000020338
+      8        1           0.000000213   -0.000001276    0.000000039
+      9        1           0.000002776   -0.000001400    0.000003980
+     10        1          -0.000001153   -0.000002700    0.000000033
+     11        1           0.000000618   -0.000001210    0.000000560
+     12        1          -0.000001055    0.000001220    0.000000330
+     13        1           0.000000017    0.000002104    0.000002825
+     14        1           0.000000791   -0.000000175    0.000000339
+     15        1          -0.000002335    0.000001241    0.000002595
+     16        1          -0.000001574    0.000004604    0.000005925
+     17        1          -0.000000106   -0.000001222   -0.000000848
+     18        1           0.000009081    0.000023869   -0.000003574
+     19        8          -0.000000891   -0.000004743   -0.000008103
+     20        8           0.000000883    0.000002739    0.000008903
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.000023869 RMS     0.000006594
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+          ******** Start new reaction path calculation ********
+ Supplied step size of   0.1000 bohr.
+    Integration on MW PES will use step size of   0.2517 sqrt(amu)*bohr.
+ Point Number:   0          Path Number:   1
+ Calculating another point on the path.
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687534    1.408557    0.643507
+      2          6           0       -1.928224    0.142750    0.283681
+      3          8           0       -2.700351   -0.706088   -0.553620
+      4          6           0       -0.639851    0.452602   -0.459453
+      5          6           0        0.149835   -0.806696   -0.884359
+      6          6           0        0.617305   -1.620313    0.242551
+      7          8           0        1.645260   -1.293786    0.963296
+      8          1           0       -3.608357    1.170831    1.181685
+      9          1           0       -2.950240    1.961951   -0.260052
+     10          1           0       -2.084410    2.052994    1.285322
+     11          1           0       -1.676835   -0.393649    1.210937
+     12          1           0       -3.541527   -0.878079   -0.128446
+     13          1           0       -0.876650    1.018512   -1.363463
+     14          1           0       -0.015463    1.092603    0.165334
+     15          1           0        1.031298   -0.458007   -1.448627
+     16          1           0       -0.485259   -1.415920   -1.526416
+     17          1           0        0.112675   -2.523081    0.567093
+     18          1           0        1.961753   -0.353370    0.806443
+     19          8           0        2.509012    1.160823    0.461514
+     20          8           0        2.677991    1.076154   -0.771457
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519307   0.000000
+     3  O    2.430020   1.420485   0.000000
+     4  C    2.514632   1.519263   2.365817   0.000000
+     5  C    3.910548   2.565949   2.871075   1.545957   0.000000
+     6  C    4.500753   3.096740   3.532214   2.523931   1.466434
+     7  O    5.116446   3.910920   4.640124   3.208709   2.426393
+     8  H    1.092732   2.164765   2.712670   3.467162   4.722622
+     9  H    1.091640   2.156306   2.695748   2.766910   4.203050
+    10  H    1.091322   2.162570   3.372480   2.773489   4.228143
+    11  H    2.142763   1.100329   2.063701   2.140486   2.810267
+    12  H    2.560062   1.953122   0.958087   3.209362   3.768641
+    13  H    2.731184   2.141460   2.637418   1.092503   2.148161
+    14  H    2.732844   2.138897   3.310711   1.090789   2.176354
+    15  H    4.657338   3.481461   3.845489   2.144858   1.103159
+    16  H    4.187630   2.790708   2.521274   2.157240   1.089374
+    17  H    4.827502   3.369309   3.531370   3.236477   2.248126
+    18  H    4.974616   3.956177   4.869229   3.003402   2.519397
+    19  O    5.205630   4.556002   5.626127   3.356351   3.353836
+    20  O    5.558910   4.816822   5.670132   3.390316   3.154274
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.297221   0.000000
+     8  H    5.150600   5.807109   0.000000
+     9  H    5.080610   5.763247   1.771325   0.000000
+    10  H    4.677587   5.021461   1.763906   1.773734   0.000000
+    11  H    2.775888   3.450781   2.485806   3.055196   2.481474
+    12  H    4.240806   5.316716   2.432887   2.903912   3.565546
+    13  H    3.431411   4.137699   3.736737   2.531278   3.089482
+    14  H    2.786803   3.014895   3.734698   3.090248   2.541114
+    15  H    2.093425   2.625423   5.576563   4.808487   4.846363
+    16  H    2.094438   3.279130   4.876354   4.369189   4.743049
+    17  H    1.083960   2.004236   5.279089   5.493735   5.126743
+    18  H    1.931491   1.004565   5.787065   5.534058   4.731950
+    19  O    3.370640   2.650085   6.159622   5.564701   4.751226
+    20  O    3.541973   3.113280   6.583456   5.720416   5.278733
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.346422   0.000000
+    13  H    3.043359   3.496269   0.000000
+    14  H    2.462191   4.050064   1.756233   0.000000
+    15  H    3.796236   4.778082   2.414048   2.470824   0.000000
+    16  H    3.155629   3.403582   2.471072   3.061930   1.795437
+    17  H    2.855059   4.067308   4.153154   3.640192   3.028453
+    18  H    3.661224   5.606731   3.827151   2.532043   2.441727
+    19  O    4.527618   6.412035   3.848831   2.542705   2.907384
+    20  O    5.005469   6.550946   3.604063   2.851762   2.350277
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.442562   0.000000
+    18  H    3.543883   2.860773   0.000000
+    19  O    4.422344   4.395989   1.646587   0.000000
+    20  O    4.097139   4.618122   2.246398   1.247374   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2465825           0.8053330           0.6957820
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.7685885259 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.7562062319 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9827 LenP2D=   22629.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.155542    0.016387    0.006296
+         Rot=    1.000000    0.000108    0.000002   -0.000047 Ang=   0.01 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.4071 S= 0.7873
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.908062979     A.U. after   24 cycles
+            NFock= 24  Conv=0.50D-08     -V/T= 2.0043
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.2471 S= 0.7236
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     1.2471,   after     0.7614
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.16333060D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.16209701D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9827 LenP2D=   22629.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000105647    0.000038739   -0.000085926
+      2        6          -0.000038951   -0.000038837    0.000032327
+      3        8           0.000215859   -0.000269957    0.000163436
+      4        6           0.000028845   -0.000015159    0.000352947
+      5        6           0.000599609    0.000008700   -0.000306188
+      6        6           0.002466417    0.002660145    0.001393711
+      7        8          -0.002233194   -0.000257092   -0.002480948
+      8        1           0.000011787   -0.000004909   -0.000016230
+      9        1           0.000021523   -0.000008833   -0.000007834
+     10        1           0.000006596   -0.000002021   -0.000013127
+     11        1          -0.000036502    0.000009875    0.000054736
+     12        1          -0.000016679    0.000064066   -0.000066286
+     13        1           0.000064695   -0.000124321   -0.000015992
+     14        1           0.000162202   -0.000004044   -0.000050415
+     15        1           0.000084562    0.000114547    0.000290858
+     16        1           0.000054597   -0.000097170    0.000095100
+     17        1           0.000066656   -0.000005566    0.000087621
+     18        1           0.001446453    0.003820515   -0.000729629
+     19        8          -0.002453222   -0.004677697    0.004465919
+     20        8          -0.000556899   -0.001210982   -0.003164079
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.004677697 RMS     0.001317282
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Pt  1 Step number   1 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  6.56D-04 Err=  9.93D-04
+      PEZero:  N= 3 I= 2 D=  6.56D-04 Err=  6.55D-04
+      PEZero:  N= 3 I= 1 D=  1.31D-03 Err=  1.06D-05
+      PEZero:  N= 4 I= 3 D=  3.28D-04 Err=  4.88D-04
+      PEZero:  N= 4 I= 2 D=  9.83D-04 Err=  4.23D-06
+      PEZero:  N= 4 I= 1 D=  1.64D-03 Err=  1.28D-06
+ Maximum DWI energy   std dev =  0.000020168 at pt    31
+ Maximum DWI gradient std dev =  0.687155268 at pt     5
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687563    1.408554    0.643589
+      2          6           0       -1.928320    0.142786    0.283641
+      3          8           0       -2.700465   -0.705975   -0.553670
+      4          6           0       -0.639930    0.452628   -0.459315
+      5          6           0        0.149637   -0.807008   -0.884384
+      6          6           0        0.618080   -1.620686    0.242941
+      7          8           0        1.643977   -1.295163    0.963516
+      8          1           0       -3.608357    1.170707    1.181713
+      9          1           0       -2.950239    1.961928   -0.259969
+     10          1           0       -2.084421    2.052961    1.285374
+     11          1           0       -1.677056   -0.393618    1.211047
+     12          1           0       -3.541551   -0.878208   -0.128460
+     13          1           0       -0.876201    1.017845   -1.363742
+     14          1           0       -0.014608    1.092359    0.164834
+     15          1           0        1.031872   -0.457675   -1.447038
+     16          1           0       -0.485655   -1.416493   -1.525906
+     17          1           0        0.112803   -2.524213    0.566230
+     18          1           0        1.963904   -0.347762    0.806979
+     19          8           0        2.509332    1.161940    0.462402
+     20          8           0        2.678797    1.076794   -0.773007
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519270   0.000000
+     3  O    2.429985   1.420455   0.000000
+     4  C    2.514557   1.519189   2.365812   0.000000
+     5  C    3.910642   2.565988   2.871003   1.546215   0.000000
+     6  C    4.501566   3.097684   3.533274   2.524754   1.467096
+     7  O    5.116120   3.910401   4.639307   3.208653   2.426125
+     8  H    1.092707   2.164643   2.712518   3.467011   4.722566
+     9  H    1.091623   2.156179   2.695618   2.766813   4.203110
+    10  H    1.091296   2.162546   3.372435   2.773366   4.228272
+    11  H    2.142652   1.100430   2.063773   2.140531   2.810432
+    12  H    2.560202   1.953143   0.958067   3.209360   3.768468
+    13  H    2.731861   2.141624   2.637368   1.092375   2.147608
+    14  H    2.733839   2.139650   3.311206   1.090801   2.176104
+    15  H    4.657010   3.481170   3.845790   2.144568   1.103157
+    16  H    4.187601   2.790537   2.521005   2.157551   1.089320
+    17  H    4.828529   3.370300   3.531946   3.237272   2.248205
+    18  H    4.974685   3.957768   4.871963   3.004010   2.522535
+    19  O    5.205898   4.556686   5.627033   3.357163   3.355406
+    20  O    5.560093   4.818133   5.671229   3.391451   3.155594
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.295244   0.000000
+     8  H    5.151304   5.806474   0.000000
+     9  H    5.081432   5.763019   1.771326   0.000000
+    10  H    4.678233   5.021402   1.763943   1.773700   0.000000
+    11  H    2.776793   3.450118   2.485537   3.055075   2.481374
+    12  H    4.241667   5.315634   2.432913   2.904017   3.565656
+    13  H    3.431640   4.137323   3.737296   2.532043   3.090158
+    14  H    2.786935   3.014807   3.735668   3.091042   2.542144
+    15  H    2.092809   2.624277   5.576171   4.808412   4.845684
+    16  H    2.094933   3.278303   4.876071   4.369268   4.743043
+    17  H    1.084519   2.003221   5.279989   5.494570   5.127912
+    18  H    1.936419   1.012140   5.787596   5.533702   4.730885
+    19  O    3.371648   2.652793   6.159838   5.564955   4.751187
+    20  O    3.543318   3.116496   6.584683   5.721252   5.279970
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.346369   0.000000
+    13  H    3.043540   3.496431   0.000000
+    14  H    2.463011   4.050739   1.756258   0.000000
+    15  H    3.795763   4.778253   2.413471   2.468979   0.000000
+    16  H    3.155412   3.403103   2.470795   3.061833   1.796786
+    17  H    2.856365   4.067705   4.153203   3.641009   3.027956
+    18  H    3.663600   5.609497   3.826632   2.529982   2.441589
+    19  O    4.528364   6.412839   3.849338   2.542373   2.907233
+    20  O    5.007199   6.552114   3.604228   2.852055   2.349740
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.441767   0.000000
+    18  H    3.547517   2.867312   0.000000
+    19  O    4.423984   4.397938   1.641775   0.000000
+    20  O    4.098426   4.620079   2.244279   1.249881   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2446601           0.8051737           0.6955843
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.6556792603 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.6432982093 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22628.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000093    0.000087    0.000016
+         Rot=    1.000000    0.000019    0.000001   -0.000012 Ang=   0.00 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.2464 S= 0.7233
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.908108969     A.U. after   20 cycles
+            NFock= 20  Conv=0.26D-08     -V/T= 2.0043
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.2179 S= 0.7116
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     1.2179,   after     0.7603
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.16320084D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15985659D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22628.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000135619    0.000047704   -0.000096463
+      2        6          -0.000084166   -0.000030346    0.000080954
+      3        8           0.000287394   -0.000329283    0.000175273
+      4        6           0.000175287   -0.000112741    0.000577254
+      5        6           0.000890714   -0.000290953   -0.000080742
+      6        6           0.003269988    0.003677717    0.001911532
+      7        8          -0.002438587    0.002208765   -0.003942600
+      8        1           0.000008585   -0.000006158   -0.000015063
+      9        1           0.000020205   -0.000006102   -0.000010640
+     10        1           0.000009948   -0.000000452   -0.000011148
+     11        1          -0.000060101    0.000022260    0.000057558
+     12        1          -0.000052520    0.000074498   -0.000067110
+     13        1           0.000081801   -0.000154235   -0.000044835
+     14        1           0.000157889   -0.000024542   -0.000092746
+     15        1           0.000173275    0.000178645    0.000330641
+     16        1           0.000078534   -0.000138089    0.000088708
+     17        1           0.000163904    0.000078365    0.000054860
+     18        1           0.000950986    0.002352894   -0.000531056
+     19        8          -0.003143604   -0.006158531    0.005560667
+     20        8          -0.000625153   -0.001389416   -0.003945043
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.006158531 RMS     0.001630110
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =           0.0000141848
+ Magnitude of corrector gradient =     0.0119724867
+ Magnitude of analytic gradient =      0.0126267806
+ Magnitude of difference =             0.0028913701
+ Angle between gradients (degrees)=   13.1531
+ Pt  1 Step number   2 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  6.56D-04 Err=  9.91D-04
+      PEZero:  N= 3 I= 2 D=  6.56D-04 Err=  6.52D-04
+      PEZero:  N= 3 I= 1 D=  1.31D-03 Err=  1.21D-05
+      PEZero:  N= 4 I= 3 D=  3.28D-04 Err=  4.85D-04
+      PEZero:  N= 4 I= 2 D=  9.83D-04 Err=  5.14D-06
+      PEZero:  N= 4 I= 1 D=  1.64D-03 Err=  1.07D-06
+ Maximum DWI energy   std dev =  0.000024152 at pt     1
+ Maximum DWI gradient std dev =  0.855974439 at pt     5
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687583    1.408542    0.643635
+      2          6           0       -1.928346    0.142794    0.283612
+      3          8           0       -2.700514   -0.705933   -0.553690
+      4          6           0       -0.639961    0.452673   -0.459284
+      5          6           0        0.149477   -0.807105   -0.884420
+      6          6           0        0.618251   -1.620958    0.243077
+      7          8           0        1.643497   -1.295815    0.963625
+      8          1           0       -3.608353    1.170643    1.181769
+      9          1           0       -2.950311    1.961917   -0.259900
+     10          1           0       -2.084452    2.052950    1.285417
+     11          1           0       -1.677015   -0.393667    1.211003
+     12          1           0       -3.541365   -0.878635   -0.128197
+     13          1           0       -0.876114    1.017879   -1.363715
+     14          1           0       -0.014510    1.092291    0.164845
+     15          1           0        1.031741   -0.458000   -1.447095
+     16          1           0       -0.486171   -1.416461   -1.525721
+     17          1           0        0.112772   -2.525071    0.565318
+     18          1           0        1.964109   -0.345171    0.807630
+     19          8           0        2.509465    1.162354    0.462665
+     20          8           0        2.679083    1.077025   -0.773485
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519268   0.000000
+     3  O    2.429970   1.420442   0.000000
+     4  C    2.514533   1.519163   2.365832   0.000000
+     5  C    3.910621   2.565922   2.870901   1.546283   0.000000
+     6  C    4.501872   3.098002   3.533598   2.525144   1.467431
+     7  O    5.116072   3.910253   4.639035   3.208747   2.426150
+     8  H    1.092704   2.164621   2.712476   3.466972   4.722490
+     9  H    1.091616   2.156161   2.695577   2.766820   4.203117
+    10  H    1.091289   2.162563   3.372429   2.773342   4.228303
+    11  H    2.142687   1.100459   2.063783   2.140474   2.810302
+    12  H    2.560438   1.953134   0.958071   3.209384   3.768197
+    13  H    2.731939   2.141648   2.637443   1.092347   2.147587
+    14  H    2.733967   2.139724   3.311272   1.090797   2.176133
+    15  H    4.657092   3.481151   3.845696   2.144687   1.103117
+    16  H    4.187238   2.790131   2.520518   2.157452   1.089326
+    17  H    4.829227   3.370908   3.532142   3.237804   2.248220
+    18  H    4.973997   3.957766   4.872582   3.003798   2.523748
+    19  O    5.206023   4.556943   5.627376   3.357457   3.356032
+    20  O    5.560507   4.818573   5.671624   3.391842   3.156131
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.294618   0.000000
+     8  H    5.151540   5.806284   0.000000
+     9  H    5.081793   5.763064   1.771312   0.000000
+    10  H    4.678534   5.021493   1.763940   1.773697   0.000000
+    11  H    2.776935   3.449763   2.485556   3.055096   2.481426
+    12  H    4.241615   5.314971   2.433113   2.904381   3.565822
+    13  H    3.431963   4.137407   3.737373   2.532175   3.090203
+    14  H    2.787154   3.014977   3.735770   3.091211   2.542284
+    15  H    2.092875   2.624452   5.576188   4.808552   4.845838
+    16  H    2.095284   3.278245   4.875616   4.368951   4.742764
+    17  H    1.084790   2.003207   5.280634   5.495137   5.128803
+    18  H    1.938475   1.015309   5.787055   5.532974   4.729706
+    19  O    3.372200   2.653951   6.159942   5.565120   4.751227
+    20  O    3.543944   3.117750   6.585107   5.721615   5.280414
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.346157   0.000000
+    13  H    3.043530   3.496689   0.000000
+    14  H    2.463014   4.050818   1.756245   0.000000
+    15  H    3.795653   4.778046   2.413521   2.469088   0.000000
+    16  H    3.154976   3.402432   2.470691   3.061751   1.796911
+    17  H    2.857119   4.067485   4.153500   3.641687   3.027720
+    18  H    3.663720   5.609867   3.826162   2.528715   2.442503
+    19  O    4.528557   6.413057   3.849505   2.542451   2.907989
+    20  O    5.007666   6.552479   3.604344   2.852392   2.350274
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.441351   0.000000
+    18  H    3.549093   2.870214   0.000000
+    19  O    4.424681   4.399065   1.639830   0.000000
+    20  O    4.099045   4.620979   2.243603   1.250647   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2438168           0.8051214           0.6955032
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.6094144937 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.5970339118 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22628.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.000037   -0.000021    0.000004
+         Rot=    1.000000   -0.000007   -0.000001   -0.000001 Ang=  -0.00 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.2177 S= 0.7115
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.908115163     A.U. after   18 cycles
+            NFock= 18  Conv=0.44D-08     -V/T= 2.0044
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.2074 S= 0.7072
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     1.2074,   after     0.7599
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.16312083D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15884708D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22628.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000142895    0.000045064   -0.000088073
+      2        6          -0.000102240   -0.000030639    0.000088305
+      3        8           0.000298229   -0.000353457    0.000187597
+      4        6           0.000219321   -0.000123069    0.000671154
+      5        6           0.000936764   -0.000422477   -0.000031669
+      6        6           0.003625361    0.004056451    0.002080450
+      7        8          -0.002594614    0.003223052   -0.004541462
+      8        1           0.000010504   -0.000008525   -0.000017191
+      9        1           0.000023213   -0.000007532   -0.000012785
+     10        1           0.000012737   -0.000000546   -0.000013140
+     11        1          -0.000076860    0.000029993    0.000068177
+     12        1          -0.000057836    0.000080383   -0.000076087
+     13        1           0.000103122   -0.000184539   -0.000056395
+     14        1           0.000181000   -0.000030578   -0.000114919
+     15        1           0.000238979    0.000231949    0.000390394
+     16        1           0.000091404   -0.000172771    0.000118310
+     17        1           0.000240084    0.000150301    0.000064184
+     18        1           0.000770729    0.001692863   -0.000458487
+     19        8          -0.003436991   -0.006714154    0.006110315
+     20        8          -0.000625799   -0.001461767   -0.004368678
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.006714154 RMS     0.001796182
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =           0.0000027793
+ Magnitude of corrector gradient =     0.0137393632
+ Magnitude of analytic gradient =      0.0139131653
+ Magnitude of difference =             0.0013047150
+ Angle between gradients (degrees)=    5.3606
+ Pt  1 Step number   3 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  6.56D-04 Err=  9.96D-04
+      PEZero:  N= 3 I= 2 D=  6.56D-04 Err=  6.55D-04
+      PEZero:  N= 3 I= 1 D=  1.31D-03 Err=  1.31D-05
+      PEZero:  N= 4 I= 3 D=  3.28D-04 Err=  4.87D-04
+      PEZero:  N= 4 I= 2 D=  9.83D-04 Err=  5.50D-06
+      PEZero:  N= 4 I= 1 D=  1.64D-03 Err=  1.28D-06
+ Maximum DWI energy   std dev =  0.000033632 at pt     1
+ Maximum DWI gradient std dev =  0.938292774 at pt     2
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence Met
+ Point Number:   1          Path Number:   1
+   CHANGE IN THE REACTION COORDINATE =    0.24730
+   NET REACTION COORDINATE UP TO THIS POINT =    0.24730
+  # OF POINTS ALONG THE PATH =   1
+  # OF STEPS =   3
+
+ Calculating another point on the path.
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687185    1.408670    0.643404
+      2          6           0       -1.928670    0.142668    0.283950
+      3          8           0       -2.699895   -0.706716   -0.553284
+      4          6           0       -0.639233    0.452125   -0.457290
+      5          6           0        0.152421   -0.808422   -0.884311
+      6          6           0        0.627995   -1.608994    0.248535
+      7          8           0        1.638913   -1.286551    0.953460
+      8          1           0       -3.607982    1.170397    1.181129
+      9          1           0       -2.949394    1.961694   -0.260388
+     10          1           0       -2.083927    2.052900    1.284957
+     11          1           0       -1.680136   -0.392489    1.213573
+     12          1           0       -3.543599   -0.875094   -0.131476
+     13          1           0       -0.872325    1.010855   -1.365750
+     14          1           0       -0.008161    1.091197    0.160666
+     15          1           0        1.041131   -0.448568   -1.432702
+     16          1           0       -0.481842   -1.423070   -1.521474
+     17          1           0        0.122779   -2.517298    0.568866
+     18          1           0        1.982977   -0.312906    0.793963
+     19          8           0        2.501925    1.147183    0.475106
+     20          8           0        2.677406    1.073717   -0.781918
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518983   0.000000
+     3  O    2.430449   1.420283   0.000000
+     4  C    2.514082   1.519160   2.366106   0.000000
+     5  C    3.913154   2.569114   2.873262   1.548562   0.000000
+     6  C    4.500292   3.099373   3.540038   2.520371   1.466433
+     7  O    5.106414   3.901097   4.629443   3.194239   2.411570
+     8  H    1.092607   2.163618   2.712262   3.466093   4.724659
+     9  H    1.091526   2.155698   2.696007   2.766661   4.205245
+    10  H    1.091120   2.162199   3.372541   2.772192   4.230147
+    11  H    2.140890   1.101073   2.064081   2.142110   2.816449
+    12  H    2.559192   1.953565   0.958180   3.209830   3.772502
+    13  H    2.736544   2.142691   2.636317   1.091700   2.142815
+    14  H    2.740619   2.145521   3.314763   1.090199   2.174009
+    15  H    4.654018   3.480829   3.851661   2.141565   1.104551
+    16  H    4.191537   2.793636   2.523948   2.161855   1.089063
+    17  H    4.828527   3.371208   3.536229   3.232821   2.243403
+    18  H    4.979648   3.970975   4.888706   3.004479   2.532405
+    19  O    5.198418   4.547061   5.617247   3.349528   3.345531
+    20  O    5.560806   4.818596   5.669002   3.389964   3.150949
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.273910   0.000000
+     8  H    5.151529   5.798132   0.000000
+     9  H    5.080013   5.751268   1.771400   0.000000
+    10  H    4.673132   5.012121   1.764181   1.773540   0.000000
+    11  H    2.781844   3.447186   2.481986   3.053810   2.479530
+    12  H    4.252671   5.310821   2.431278   2.901218   3.565120
+    13  H    3.423519   4.118631   3.741105   2.537743   3.095172
+    14  H    2.775508   2.999176   3.742503   3.096111   2.549061
+    15  H    2.084185   2.598717   5.573815   4.807075   4.838285
+    16  H    2.097435   3.262137   4.878820   4.374446   4.746062
+    17  H    1.087599   1.990305   5.281338   5.494295   5.125334
+    18  H    1.952770   1.044894   5.797319   5.532969   4.730520
+    19  O    3.340578   2.626152   6.150607   5.560688   4.744072
+    20  O    3.529711   3.108194   6.585515   5.720260   5.282146
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.348310   0.000000
+    13  H    3.045462   3.495131   0.000000
+    14  H    2.470919   4.055980   1.755898   0.000000
+    15  H    3.796210   4.784858   2.407428   2.451674   0.000000
+    16  H    3.158875   3.406865   2.469963   3.061945   1.810243
+    17  H    2.860238   4.077946   4.144976   3.633869   3.021471
+    18  H    3.687927   5.631655   3.816995   2.517379   2.421469
+    19  O    4.517251   6.403586   3.846153   2.530323   2.884453
+    20  O    5.011978   6.551477   3.597971   2.846232   2.327717
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.435656   0.000000
+    18  H    3.559359   2.893155   0.000000
+    19  O    4.415359   4.370074   1.582036   0.000000
+    20  O    4.094110   4.609352   2.210963   1.271339   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2588206           0.8061519           0.6977920
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.0435447814 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.0311685323 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22639.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.49D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000640    0.000525    0.000005
+         Rot=    1.000000    0.000118    0.000005   -0.000063 Ang=   0.02 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 1.2015 S= 0.7048
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Failed to achieve initial convergence to 1.0D-08 in 10 cycles.
+ Switch to full accuracy anyway.
+ SCF Done:  E(UwB97XD) =  -497.910204650     A.U. after   27 cycles
+            NFock= 27  Conv=0.32D-08     -V/T= 2.0045
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.9466 S= 0.5939
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.9466,   after     0.7529
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14978179D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15021583D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22639.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000329259    0.000130001   -0.000184339
+      2        6          -0.000265321   -0.000068627    0.000152129
+      3        8           0.000652572   -0.000779901    0.000442772
+      4        6           0.000118258   -0.000390075    0.001475374
+      5        6           0.002034454    0.000021665   -0.000959829
+      6        6           0.009775895    0.008977307    0.005680173
+      7        8          -0.011408865   -0.003934305   -0.007949810
+      8        1           0.000030827   -0.000019493   -0.000038807
+      9        1           0.000052031   -0.000021382   -0.000026871
+     10        1           0.000026015    0.000001576   -0.000029440
+     11        1          -0.000155633    0.000034681    0.000197397
+     12        1          -0.000103013    0.000176706   -0.000184730
+     13        1           0.000220340   -0.000450666   -0.000088921
+     14        1           0.000667251   -0.000030953   -0.000178572
+     15        1           0.000128218    0.000337581    0.001134441
+     16        1           0.000238200   -0.000387797    0.000259058
+     17        1           0.000338678   -0.000467528   -0.000072106
+     18        1           0.006813042    0.017290276   -0.003345582
+     19        8          -0.008798385   -0.017606776    0.016579435
+     20        8          -0.000693825   -0.002812291   -0.012861774
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.017606776 RMS     0.005198942
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Pt  2 Step number   1 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  8.74D-05
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  5.79D-05
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  8.34D-07
+ Maximum DWI energy   std dev =  0.000311077 at pt    -1
+ Maximum DWI gradient std dev =  0.597672838 at pt    57
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687222    1.408660    0.643440
+      2          6           0       -1.928649    0.142707    0.283850
+      3          8           0       -2.699979   -0.706593   -0.553335
+      4          6           0       -0.639427    0.452304   -0.457461
+      5          6           0        0.151852   -0.808199   -0.884597
+      6          6           0        0.628053   -1.610420    0.248673
+      7          8           0        1.638134   -1.289109    0.954732
+      8          1           0       -3.607959    1.170327    1.181135
+      9          1           0       -2.949429    1.961630   -0.260378
+     10          1           0       -2.083963    2.052929    1.284922
+     11          1           0       -1.680008   -0.392518    1.213616
+     12          1           0       -3.543420   -0.875465   -0.131258
+     13          1           0       -0.872225    1.010801   -1.365829
+     14          1           0       -0.007487    1.091036    0.160498
+     15          1           0        1.040681   -0.449025   -1.432010
+     16          1           0       -0.482523   -1.423016   -1.521363
+     17          1           0        0.121862   -2.519876    0.567636
+     18          1           0        1.990700   -0.292848    0.791896
+     19          8           0        2.502686    1.149063    0.475051
+     20          8           0        2.678102    1.074380   -0.782630
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519004   0.000000
+     3  O    2.430376   1.420260   0.000000
+     4  C    2.513974   1.519041   2.366032   0.000000
+     5  C    3.912761   2.568652   2.872803   1.548365   0.000000
+     6  C    4.501303   3.100229   3.540610   2.521896   1.467865
+     7  O    5.107207   3.901554   4.629559   3.195950   2.413181
+     8  H    1.092555   2.163610   2.712129   3.465940   4.724193
+     9  H    1.091520   2.155610   2.695824   2.766409   4.204705
+    10  H    1.091102   2.162225   3.372481   2.772109   4.229862
+    11  H    2.140986   1.101251   2.064243   2.142202   2.816203
+    12  H    2.559386   1.953580   0.958154   3.209759   3.771880
+    13  H    2.736725   2.142675   2.636337   1.091442   2.142213
+    14  H    2.741368   2.146021   3.315198   1.090505   2.173639
+    15  H    4.653573   3.480121   3.851097   2.141238   1.103940
+    16  H    4.191117   2.793128   2.523382   2.161789   1.088992
+    17  H    4.830124   3.372608   3.536574   3.234848   2.244932
+    18  H    4.979973   3.976069   4.897275   3.005614   2.541176
+    19  O    5.199125   4.548191   5.618609   3.350811   3.347527
+    20  O    5.561666   4.819497   5.669938   3.390976   3.152212
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.273587   0.000000
+     8  H    5.152265   5.798412   0.000000
+     9  H    5.081048   5.752350   1.771379   0.000000
+    10  H    4.674288   5.013208   1.764178   1.773505   0.000000
+    11  H    2.782363   3.446877   2.482043   3.053867   2.479612
+    12  H    4.252727   5.310271   2.431421   2.901484   3.565260
+    13  H    3.424653   4.120254   3.741218   2.537888   3.095290
+    14  H    2.776608   3.000661   3.743179   3.096788   2.549769
+    15  H    2.084178   2.599852   5.573211   4.806761   4.837861
+    16  H    2.097982   3.262846   4.878246   4.373962   4.745740
+    17  H    1.088612   1.990907   5.282570   5.495665   5.127447
+    18  H    1.971774   1.069278   5.799774   5.531260   4.727434
+    19  O    3.343687   2.631013   6.151341   5.561177   4.744494
+    20  O    3.531917   3.112241   6.586361   5.720933   5.282954
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.348239   0.000000
+    13  H    3.045546   3.495346   0.000000
+    14  H    2.471298   4.056485   1.756099   0.000000
+    15  H    3.795349   4.784118   2.407214   2.450821   0.000000
+    16  H    3.158482   3.406067   2.469721   3.061825   1.810191
+    17  H    2.861761   4.077601   4.146345   3.636094   3.021794
+    18  H    3.696198   5.640757   3.814658   2.511285   2.423362
+    19  O    4.518504   6.404820   3.846815   2.530471   2.885866
+    20  O    5.012974   6.552367   3.598471   2.846429   2.328863
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.435631   0.000000
+    18  H    3.570053   2.915905   0.000000
+    19  O    4.417322   4.374701   1.562571   0.000000
+    20  O    4.095395   4.612620   2.195670   1.272049   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2557906           0.8059204           0.6974356
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.8547063737 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.8423343618 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.49D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000186    0.000301   -0.000031
+         Rot=    1.000000    0.000043   -0.000008   -0.000034 Ang=   0.01 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.9462 S= 0.5937
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.910892692     A.U. after   26 cycles
+            NFock= 26  Conv=0.56D-08     -V/T= 2.0045
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.8778 S= 0.5620
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.8778,   after     0.7516
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14996032D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.14980436D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000432328    0.000142762   -0.000168606
+      2        6          -0.000448244   -0.000052210    0.000148272
+      3        8           0.000768548   -0.000908500    0.000501374
+      4        6           0.000221360   -0.000299673    0.002276050
+      5        6           0.002129435   -0.000690630   -0.001179443
+      6        6           0.016202996    0.012451931    0.010084218
+      7        8          -0.016937682   -0.001999732   -0.013423834
+      8        1           0.000028764   -0.000043588   -0.000040133
+      9        1           0.000061504   -0.000037791   -0.000025318
+     10        1           0.000026618   -0.000001722   -0.000038390
+     11        1          -0.000216909    0.000074583    0.000229343
+     12        1          -0.000169496    0.000189768   -0.000199501
+     13        1           0.000309430   -0.000572655   -0.000213244
+     14        1           0.000723025   -0.000172525   -0.000401146
+     15        1           0.000500597    0.000513077    0.001460983
+     16        1           0.000160518   -0.000496806    0.000282019
+     17        1           0.000431227   -0.000537255   -0.000317071
+     18        1           0.007181975    0.017918442   -0.003229322
+     19        8          -0.011661442   -0.022530524    0.024531695
+     20        8           0.000255448   -0.002946952   -0.020277946
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.024531695 RMS     0.007138669
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =           0.0002319955
+ Magnitude of corrector gradient =     0.0554215155
+ Magnitude of analytic gradient =      0.0552958928
+ Magnitude of difference =             0.0184072126
+ Angle between gradients (degrees)=   19.1397
+ Pt  2 Step number   2 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  1.46D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  9.74D-05
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  7.05D-07
+ Maximum DWI energy   std dev =  0.000298854 at pt    75
+ Maximum DWI gradient std dev =  0.750652177 at pt    55
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687254    1.408646    0.643472
+      2          6           0       -1.928631    0.142718    0.283797
+      3          8           0       -2.700033   -0.706530   -0.553364
+      4          6           0       -0.639515    0.452390   -0.457592
+      5          6           0        0.151529   -0.808087   -0.884710
+      6          6           0        0.627854   -1.611280    0.248701
+      7          8           0        1.637782   -1.290635    0.955379
+      8          1           0       -3.607980    1.170327    1.181224
+      9          1           0       -2.949570    1.961635   -0.260297
+     10          1           0       -2.084049    2.052938    1.284982
+     11          1           0       -1.679576   -0.392701    1.213340
+     12          1           0       -3.543039   -0.876159   -0.130692
+     13          1           0       -0.872630    1.011666   -1.365489
+     14          1           0       -0.008188    1.091114    0.161031
+     15          1           0        1.039430   -0.450496   -1.433753
+     16          1           0       -0.483430   -1.422137   -1.521751
+     17          1           0        0.120529   -2.521452    0.566326
+     18          1           0        1.992952   -0.283363    0.792120
+     19          8           0        2.503134    1.150007    0.474552
+     20          8           0        2.678365    1.074717   -0.782467
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519029   0.000000
+     3  O    2.430339   1.420254   0.000000
+     4  C    2.513961   1.519004   2.366009   0.000000
+     5  C    3.912535   2.568366   2.872544   1.548219   0.000000
+     6  C    4.501748   3.100541   3.540722   2.522659   1.468545
+     7  O    5.107772   3.901899   4.629699   3.196983   2.414068
+     8  H    1.092571   2.163694   2.712149   3.465968   4.723994
+     9  H    1.091514   2.155647   2.695785   2.766423   4.204529
+    10  H    1.091102   2.162283   3.372479   2.772183   4.229756
+    11  H    2.141265   1.101250   2.064234   2.141942   2.815547
+    12  H    2.559694   1.953516   0.958167   3.209728   3.771340
+    13  H    2.736124   2.142511   2.636503   1.091517   2.142791
+    14  H    2.740615   2.145374   3.314802   1.090521   2.173947
+    15  H    4.653971   3.480124   3.850223   2.141717   1.103489
+    16  H    4.190270   2.792379   2.522538   2.161168   1.089060
+    17  H    4.830659   3.372933   3.535988   3.235708   2.245459
+    18  H    4.978887   3.977279   4.900358   3.005494   2.545178
+    19  O    5.199572   4.548797   5.619277   3.351388   3.348397
+    20  O    5.561895   4.819746   5.670317   3.391337   3.152824
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.273641   0.000000
+     8  H    5.152595   5.798738   0.000000
+     9  H    5.081610   5.753166   1.771342   0.000000
+    10  H    4.674911   5.013995   1.764124   1.773513   0.000000
+    11  H    2.782031   3.446402   2.482505   3.054077   2.479896
+    12  H    4.252139   5.309637   2.431758   2.902081   3.565445
+    13  H    3.425917   4.121794   3.740730   2.537237   3.094637
+    14  H    2.777619   3.002154   3.742403   3.096297   2.549034
+    15  H    2.085058   2.602270   5.573473   4.807026   4.838887
+    16  H    2.098863   3.263894   4.877475   4.372988   4.745090
+    17  H    1.089347   1.992067   5.282907   5.496078   5.128516
+    18  H    1.980445   1.080461   5.799575   5.529568   4.724739
+    19  O    3.345503   2.633773   6.151871   5.561539   4.744927
+    20  O    3.533056   3.114131   6.586605   5.721271   5.283167
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.347903   0.000000
+    13  H    3.045286   3.495667   0.000000
+    14  H    2.470344   4.055914   1.756085   0.000000
+    15  H    3.795186   4.783114   2.408018   2.453039   0.000000
+    16  H    3.157725   3.405047   2.469675   3.061705   1.808571
+    17  H    2.861919   4.076095   4.147433   3.637508   3.022177
+    18  H    3.698222   5.643597   3.813651   2.508390   2.427272
+    19  O    4.518940   6.405300   3.847164   2.531501   2.888887
+    20  O    5.012805   6.552602   3.599091   2.847459   2.331642
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.435842   0.000000
+    18  H    3.575370   2.926772   0.000000
+    19  O    4.418224   4.377766   1.554247   0.000000
+    20  O    4.096067   4.614564   2.189405   1.271405   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2542031           0.8058364           0.6972494
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.7741861554 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.7618156265 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22631.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.000080    0.000052   -0.000028
+         Rot=    1.000000   -0.000010   -0.000007   -0.000006 Ang=  -0.00 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.8777 S= 0.5619
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.911117265     A.U. after   21 cycles
+            NFock= 21  Conv=0.55D-08     -V/T= 2.0046
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.8540 S= 0.5507
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.8540,   after     0.7513
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14993707D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.14948695D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22631.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000452300    0.000128957   -0.000115125
+      2        6          -0.000507726   -0.000079232    0.000073503
+      3        8           0.000762358   -0.000957300    0.000548868
+      4        6           0.000166786   -0.000154843    0.002539474
+      5        6           0.001928408   -0.000896411   -0.001504023
+      6        6           0.018675323    0.013545742    0.011820705
+      7        8          -0.019262478   -0.001205583   -0.015548551
+      8        1           0.000046013   -0.000057096   -0.000053351
+      9        1           0.000073932   -0.000049666   -0.000031056
+     10        1           0.000031488   -0.000002121   -0.000047872
+     11        1          -0.000269777    0.000089631    0.000294898
+     12        1          -0.000179801    0.000192500   -0.000226137
+     13        1           0.000414421   -0.000723553   -0.000216365
+     14        1           0.000858765   -0.000211607   -0.000485045
+     15        1           0.000756455    0.000659394    0.001725358
+     16        1           0.000125470   -0.000610678    0.000431370
+     17        1           0.000623151   -0.000383379   -0.000427757
+     18        1           0.007478817    0.018250692   -0.003303980
+     19        8          -0.012946962   -0.024559569    0.028307852
+     20        8           0.000773058   -0.002975880   -0.023782767
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.028307852 RMS     0.008016974
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =           0.0000597282
+ Magnitude of corrector gradient =     0.0643058061
+ Magnitude of analytic gradient =      0.0620992107
+ Magnitude of difference =             0.0102850566
+ Angle between gradients (degrees)=    9.1177
+ Pt  2 Step number   3 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  2.45D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  1.63D-04
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  1.08D-06
+ Maximum DWI energy   std dev =  0.000307908 at pt    75
+ Maximum DWI gradient std dev =  0.797611278 at pt    55
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687268    1.408640    0.643485
+      2          6           0       -1.928621    0.142721    0.283777
+      3          8           0       -2.700055   -0.706505   -0.553376
+      4          6           0       -0.639548    0.452418   -0.457655
+      5          6           0        0.151395   -0.808033   -0.884745
+      6          6           0        0.627708   -1.611662    0.248680
+      7          8           0        1.637662   -1.291297    0.955664
+      8          1           0       -3.607995    1.170337    1.181270
+      9          1           0       -2.949641    1.961645   -0.260255
+     10          1           0       -2.084091    2.052940    1.285018
+     11          1           0       -1.679357   -0.392798    1.213189
+     12          1           0       -3.542858   -0.876484   -0.130414
+     13          1           0       -0.872865    1.012146   -1.365295
+     14          1           0       -0.008648    1.091178    0.161345
+     15          1           0        1.038787   -0.451268   -1.434782
+     16          1           0       -0.483831   -1.421670   -1.521983
+     17          1           0        0.119867   -2.522027    0.565787
+     18          1           0        1.993642   -0.280013    0.792188
+     19          8           0        2.503324    1.150383    0.474245
+     20          8           0        2.678448    1.074849   -0.782276
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519042   0.000000
+     3  O    2.430324   1.420253   0.000000
+     4  C    2.513967   1.518994   2.366000   0.000000
+     5  C    3.912433   2.568236   2.872434   1.548138   0.000000
+     6  C    4.501907   3.100630   3.540708   2.522950   1.468791
+     7  O    5.108046   3.902077   4.629791   3.197452   2.414464
+     8  H    1.092583   2.163744   2.712174   3.466001   4.723915
+     9  H    1.091513   2.155676   2.695781   2.766453   4.204465
+    10  H    1.091104   2.162312   3.372482   2.772234   4.229708
+    11  H    2.141407   1.101235   2.064216   2.141801   2.815208
+    12  H    2.559833   1.953483   0.958179   3.209716   3.771101
+    13  H    2.735776   2.142419   2.636588   1.091578   2.143149
+    14  H    2.740119   2.144961   3.314538   1.090509   2.174148
+    15  H    4.654239   3.480197   3.849800   2.142016   1.103307
+    16  H    4.189874   2.792043   2.522164   2.160844   1.089098
+    17  H    4.830755   3.372939   3.535620   3.235966   2.245621
+    18  H    4.978412   3.977603   4.901349   3.005371   2.546524
+    19  O    5.199768   4.549043   5.619536   3.351602   3.348704
+    20  O    5.561936   4.819794   5.670442   3.391445   3.153053
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.273761   0.000000
+     8  H    5.152711   5.798918   0.000000
+     9  H    5.081827   5.753558   1.771325   0.000000
+    10  H    4.675164   5.014363   1.764095   1.773521   0.000000
+    11  H    2.781808   3.446191   2.482751   3.054187   2.480040
+    12  H    4.251802   5.309371   2.431920   2.902368   3.565525
+    13  H    3.426515   4.122553   3.740449   2.536860   3.094266
+    14  H    2.778115   3.002909   3.741900   3.095949   2.548547
+    15  H    2.085557   2.603561   5.573680   4.807204   4.839497
+    16  H    2.099253   3.264423   4.877139   4.372527   4.744786
+    17  H    1.089598   1.992587   5.282929   5.496139   5.128845
+    18  H    1.983549   1.084500   5.799417   5.528898   4.723712
+    19  O    3.346298   2.634945   6.152114   5.561696   4.745139
+    20  O    3.533518   3.114854   6.586653   5.721389   5.283195
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.347734   0.000000
+    13  H    3.045140   3.495815   0.000000
+    14  H    2.469783   4.055547   1.756060   0.000000
+    15  H    3.795191   4.782641   2.408489   2.454359   0.000000
+    16  H    3.157376   3.404606   2.469688   3.061665   1.807664
+    17  H    2.861810   4.075300   4.147888   3.638041   3.022372
+    18  H    3.698768   5.644449   3.813302   2.507447   2.429089
+    19  O    4.519100   6.405476   3.847294   2.532077   2.890422
+    20  O    5.012618   6.552655   3.599398   2.848012   2.333086
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.435985   0.000000
+    18  H    3.577239   2.930685   0.000000
+    19  O    4.418538   4.379023   1.551418   0.000000
+    20  O    4.096313   4.615315   2.187133   1.270912   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2535648           0.8058098           0.6971734
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.7460967398 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.7337267076 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.000059   -0.000006   -0.000013
+         Rot=    1.000000   -0.000010   -0.000003    0.000001 Ang=  -0.00 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.8540 S= 0.5507
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.911165231     A.U. after   20 cycles
+            NFock= 20  Conv=0.37D-08     -V/T= 2.0046
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.8472 S= 0.5475
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.8472,   after     0.7512
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14991774D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.14933906D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9826 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000456314    0.000121705   -0.000088624
+      2        6          -0.000527687   -0.000096719    0.000033053
+      3        8           0.000746343   -0.000973169    0.000570484
+      4        6           0.000127421   -0.000077390    0.002622990
+      5        6           0.001827758   -0.000966242   -0.001667239
+      6        6           0.019512185    0.013886727    0.012414606
+      7        8          -0.020034502   -0.000861425   -0.016302216
+      8        1           0.000055141   -0.000062948   -0.000060201
+      9        1           0.000079822   -0.000055025   -0.000033630
+     10        1           0.000033572   -0.000002238   -0.000052484
+     11        1          -0.000292190    0.000094804    0.000326549
+     12        1          -0.000177408    0.000193146   -0.000240229
+     13        1           0.000463768   -0.000794973   -0.000209545
+     14        1           0.000927570   -0.000223648   -0.000514284
+     15        1           0.000860976    0.000724483    0.001844141
+     16        1           0.000105524   -0.000661849    0.000507587
+     17        1           0.000693380   -0.000321576   -0.000460574
+     18        1           0.007562122    0.018287706   -0.003301711
+     19        8          -0.013407161   -0.025231016    0.029750685
+     20        8           0.000987051   -0.002980353   -0.025139358
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.029750685 RMS     0.008332966
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =           0.0000092949
+ Magnitude of corrector gradient =     0.0658646391
+ Magnitude of analytic gradient =      0.0645468782
+ Magnitude of difference =             0.0042629038
+ Angle between gradients (degrees)=    3.5631
+ Pt  2 Step number   4 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  2.89D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  1.93D-04
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  1.33D-06
+ Maximum DWI energy   std dev =  0.000311262 at pt    76
+ Maximum DWI gradient std dev =  0.811418180 at pt    55
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence Met
+ Point Number:   2          Path Number:   1
+   CHANGE IN THE REACTION COORDINATE =    0.24276
+   NET REACTION COORDINATE UP TO THIS POINT =    0.49006
+  # OF POINTS ALONG THE PATH =   2
+  # OF STEPS =   4
+
+ Calculating another point on the path.
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687087    1.408649    0.643579
+      2          6           0       -1.929036    0.142624    0.283832
+      3          8           0       -2.699934   -0.706812   -0.553214
+      4          6           0       -0.639555    0.452349   -0.456174
+      5          6           0        0.152281   -0.808796   -0.885546
+      6          6           0        0.637525   -1.604396    0.254670
+      7          8           0        1.630694   -1.289343    0.948860
+      8          1           0       -3.607680    1.169792    1.180853
+      9          1           0       -2.948921    1.961280   -0.260423
+     10          1           0       -2.083750    2.052787    1.284751
+     11          1           0       -1.682222   -0.391900    1.215728
+     12          1           0       -3.544768   -0.874046   -0.133033
+     13          1           0       -0.869036    1.005355   -1.367393
+     14          1           0       -0.001231    1.089383    0.156874
+     15          1           0        1.047098   -0.443495   -1.419227
+     16          1           0       -0.482130   -1.427672   -1.517841
+     17          1           0        0.126739   -2.521272    0.564940
+     18          1           0        2.029036   -0.205077    0.775773
+     19          8           0        2.498158    1.140808    0.486200
+     20          8           0        2.678840    1.073554   -0.792385
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518841   0.000000
+     3  O    2.430567   1.420025   0.000000
+     4  C    2.513235   1.518651   2.366058   0.000000
+     5  C    3.913731   2.569927   2.873321   1.549791   0.000000
+     6  C    4.503635   3.104861   3.549220   2.523179   1.472594
+     7  O    5.100547   3.894158   4.620595   3.187733   2.404511
+     8  H    1.092341   2.162768   2.711574   3.464729   4.724629
+     9  H    1.091411   2.154969   2.695633   2.765567   4.204944
+    10  H    1.090885   2.162059   3.372416   2.770907   4.230684
+    11  H    2.139880   1.102299   2.064961   2.143634   2.820382
+    12  H    2.559187   1.953966   0.958261   3.209985   3.773420
+    13  H    2.740795   2.143466   2.635638   1.090319   2.136916
+    14  H    2.748206   2.151489   3.318666   1.090458   2.171012
+    15  H    4.650778   3.478695   3.854809   2.138879   1.104064
+    16  H    4.192647   2.793814   2.523648   2.164810   1.088706
+    17  H    4.834054   3.376622   3.540143   3.236094   2.244357
+    18  H    4.986322   4.003653   4.937722   3.011857   2.578113
+    19  O    5.194542   4.542837   5.613754   3.347729   3.344515
+    20  O    5.564840   4.822592   5.670812   3.392739   3.152050
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.252015   0.000000
+     8  H    5.155162   5.791522   0.000000
+     9  H    5.083499   5.744718   1.771354   0.000000
+    10  H    4.673477   5.007969   1.764323   1.773262   0.000000
+    11  H    2.788369   3.442678   2.479413   3.053032   2.478404
+    12  H    4.263250   5.303618   2.430540   2.900058   3.565254
+    13  H    3.422223   4.108445   3.744431   2.542655   3.099437
+    14  H    2.770202   2.991448   3.749863   3.102131   2.556784
+    15  H    2.077828   2.581449   5.570464   4.805615   4.831680
+    16  H    2.103961   3.250811   4.878405   4.376204   4.746926
+    17  H    1.094456   1.981646   5.286699   5.498562   5.130927
+    18  H    2.041064   1.168019   5.816092   5.526922   4.719325
+    19  O    3.324410   2.621485   6.145294   5.558893   4.739544
+    20  O    3.526287   3.116701   6.589633   5.722127   5.287311
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.349616   0.000000
+    13  H    3.047311   3.495044   0.000000
+    14  H    2.478125   4.061497   1.756000   0.000000
+    15  H    3.794052   4.787995   2.402795   2.435735   0.000000
+    16  H    3.159975   3.406457   2.468189   3.061291   1.821226
+    17  H    2.868813   4.084175   4.142775   3.635895   3.016809
+    18  H    3.741911   5.686892   3.802253   2.486091   2.416417
+    19  O    4.511871   6.400003   3.846056   2.521516   2.871628
+    20  O    5.019854   6.554478   3.594817   2.843259   2.314509
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.429951   0.000000
+    18  H    3.614050   3.004654   0.000000
+    19  O    4.415358   4.363560   1.454419   0.000000
+    20  O    4.095625   4.612843   2.125150   1.293038   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2593905           0.8061212           0.6983572
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.7608515190 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.7484928842 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22638.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.49D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000779    0.000951   -0.000065
+         Rot=    1.000000    0.000154   -0.000015   -0.000114 Ang=   0.02 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.8448 S= 0.5463
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Failed to achieve initial convergence to 1.0D-08 in 10 cycles.
+ Switch to full accuracy anyway.
+ SCF Done:  E(UwB97XD) =  -497.918769572     A.U. after   25 cycles
+            NFock= 25  Conv=0.59D-08     -V/T= 2.0047
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7583 S= 0.5041
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7583,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15353222D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15381716D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22638.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000373637    0.000085922   -0.000327917
+      2        6          -0.000414987    0.000171410    0.000989001
+      3        8           0.000922403   -0.001062950    0.000498883
+      4        6           0.000769372   -0.002565398    0.001953160
+      5        6           0.003261362    0.002518164   -0.001223229
+      6        6           0.015414892    0.010233665    0.011562262
+      7        8          -0.016265422    0.002603118   -0.012373129
+      8        1          -0.000077222    0.000012357    0.000036697
+      9        1           0.000034590    0.000012146   -0.000063946
+     10        1           0.000080912    0.000034900    0.000034136
+     11        1          -0.000262092    0.000224731   -0.000180139
+     12        1          -0.000082888    0.000269319   -0.000214948
+     13        1          -0.000215242    0.000030738   -0.000435690
+     14        1           0.000288098   -0.000083328   -0.000211073
+     15        1          -0.001872089   -0.001015160    0.000965062
+     16        1           0.000917438   -0.000433440   -0.000291532
+     17        1           0.000912887   -0.000082850   -0.001592587
+     18        1           0.011998101    0.030696466   -0.005132130
+     19        8          -0.016248551   -0.041244967    0.020700866
+     20        8           0.000464800   -0.000404842   -0.014693745
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.041244967 RMS     0.008819261
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Pt  3 Step number   1 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  1.73D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  1.15D-04
+      PEZero:  N= 3 I= 1 D=  2.61D-03 Err=  6.55D-07
+ Maximum DWI energy   std dev =  0.000228892 at pt    23
+ Maximum DWI gradient std dev =  0.233267310 at pt    58
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687086    1.408683    0.643448
+      2          6           0       -1.928862    0.142697    0.283868
+      3          8           0       -2.699828   -0.706811   -0.553203
+      4          6           0       -0.639457    0.452174   -0.456564
+      5          6           0        0.152225   -0.808213   -0.885439
+      6          6           0        0.635926   -1.605892    0.253996
+      7          8           0        1.631918   -1.289730    0.950348
+      8          1           0       -3.607753    1.170008    1.180917
+      9          1           0       -2.949065    1.961358   -0.260536
+     10          1           0       -2.083775    2.052926    1.284734
+     11          1           0       -1.681554   -0.391941    1.215005
+     12          1           0       -3.544177   -0.874618   -0.132392
+     13          1           0       -0.870263    1.007183   -1.366978
+     14          1           0       -0.003009    1.089833    0.157950
+     15          1           0        1.043127   -0.446967   -1.423097
+     16          1           0       -0.481732   -1.426347   -1.519158
+     17          1           0        0.125448   -2.522140    0.563190
+     18          1           0        2.033433   -0.188667    0.774681
+     19          8           0        2.498741    1.141089    0.483650
+     20          8           0        2.678836    1.074086   -0.790125
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518856   0.000000
+     3  O    2.430525   1.420120   0.000000
+     4  C    2.513508   1.518743   2.365949   0.000000
+     5  C    3.913287   2.569519   2.873128   1.548958   0.000000
+     6  C    4.503526   3.104286   3.547840   2.523317   1.472607
+     7  O    5.101903   3.895536   4.622173   3.189479   2.406547
+     8  H    1.092459   2.163040   2.711817   3.465171   4.724470
+     9  H    1.091453   2.155161   2.695719   2.765927   4.204643
+    10  H    1.091000   2.162107   3.372489   2.771386   4.230303
+    11  H    2.140098   1.101823   2.064602   2.143044   2.819201
+    12  H    2.559297   1.953829   0.958210   3.209808   3.772914
+    13  H    2.739317   2.143189   2.635776   1.090945   2.138463
+    14  H    2.746204   2.149844   3.317604   1.090551   2.171483
+    15  H    4.650649   3.477664   3.851486   2.138628   1.101490
+    16  H    4.192594   2.794098   2.524034   2.163983   1.088848
+    17  H    4.834062   3.376324   3.538917   3.235973   2.244279
+    18  H    4.985182   4.006304   4.943228   3.011806   2.584333
+    19  O    5.195184   4.543167   5.613815   3.347670   3.343699
+    20  O    5.564189   4.822015   5.670781   3.392507   3.152126
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.255733   0.000000
+     8  H    5.154960   5.792895   0.000000
+     9  H    5.083520   5.746409   1.771410   0.000000
+    10  H    4.673985   5.009145   1.764322   1.773407   0.000000
+    11  H    2.787100   3.443133   2.480139   3.053166   2.478713
+    12  H    4.261141   5.304396   2.430909   2.900575   3.565324
+    13  H    3.424080   4.111778   3.743278   2.540881   3.098026
+    14  H    2.772074   2.993861   3.747942   3.100634   2.554755
+    15  H    2.078836   2.586536   5.570115   4.805119   4.833149
+    16  H    2.103680   3.253405   4.878880   4.375889   4.746966
+    17  H    1.093480   1.984485   5.286807   5.498446   5.131522
+    18  H    2.057344   1.185079   5.816700   5.524451   4.715537
+    19  O    3.326969   2.622608   6.146242   5.559248   4.740531
+    20  O    3.527882   3.116554   6.589037   5.721974   5.286363
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.349004   0.000000
+    13  H    3.046699   3.495024   0.000000
+    14  H    2.475991   4.059955   1.756236   0.000000
+    15  H    3.792953   4.784576   2.403906   2.440464   0.000000
+    16  H    3.159939   3.406772   2.469045   3.061540   1.814829
+    17  H    2.868425   4.082195   4.144045   3.636903   3.015595
+    18  H    3.746510   5.692367   3.801079   2.482340   2.424387
+    19  O    4.512198   6.399957   3.846160   2.523383   2.876877
+    20  O    5.018245   6.554079   3.596295   2.844537   2.321595
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.430145   0.000000
+    18  H    3.622099   3.021627   0.000000
+    19  O    4.414316   4.365558   1.438562   0.000000
+    20  O    4.095466   4.613468   2.111801   1.288187   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2589477           0.8060857           0.6981932
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.7438652720 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.7315081689 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000119    0.000348   -0.000088
+         Rot=    1.000000    0.000036   -0.000013   -0.000035 Ang=   0.01 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7583 S= 0.5041
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.919439349     A.U. after   20 cycles
+            NFock= 20  Conv=0.34D-08     -V/T= 2.0047
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7578 S= 0.5039
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7578,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15268464D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15285629D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000375819    0.000116630   -0.000209446
+      2        6          -0.000471888    0.000134141    0.000628373
+      3        8           0.000914009   -0.001031342    0.000522755
+      4        6           0.000461767   -0.002000376    0.001966121
+      5        6           0.001812249    0.001817068   -0.001674229
+      6        6           0.020922940    0.012426134    0.014981677
+      7        8          -0.020797214    0.001836746   -0.015878368
+      8        1          -0.000010089    0.000003821   -0.000007761
+      9        1           0.000055235   -0.000016807   -0.000049428
+     10        1           0.000046248    0.000007652   -0.000011071
+     11        1          -0.000260296    0.000138832    0.000079861
+     12        1          -0.000139991    0.000241389   -0.000208366
+     13        1          -0.000018092   -0.000286609   -0.000207279
+     14        1           0.000393262   -0.000179635   -0.000322440
+     15        1          -0.000645218   -0.000487769    0.000848661
+     16        1           0.000670354   -0.000459114   -0.000092213
+     17        1           0.000564926   -0.000579979   -0.001415762
+     18        1           0.012319809    0.031520780   -0.005226295
+     19        8          -0.017615464   -0.042944693    0.026010403
+     20        8           0.001421633   -0.000256867   -0.019735191
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.042944693 RMS     0.009937954
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =           0.0000593481
+ Magnitude of corrector gradient =     0.0799478338
+ Magnitude of analytic gradient =      0.0769790621
+ Magnitude of difference =             0.0123428566
+ Angle between gradients (degrees)=    8.7585
+ Pt  3 Step number   2 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  2.49D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  1.66D-04
+      PEZero:  N= 3 I= 1 D=  2.61D-03 Err=  4.00D-07
+ Maximum DWI energy   std dev =  0.000224968 at pt    24
+ Maximum DWI gradient std dev =  0.238068170 at pt    57
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence Met
+ Point Number:   3          Path Number:   1
+   CHANGE IN THE REACTION COORDINATE =    0.24854
+   NET REACTION COORDINATE UP TO THIS POINT =    0.73860
+  # OF POINTS ALONG THE PATH =   3
+  # OF STEPS =   2
+
+ Calculating another point on the path.
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687055    1.408673    0.643546
+      2          6           0       -1.929100    0.142687    0.284049
+      3          8           0       -2.699842   -0.706905   -0.553191
+      4          6           0       -0.639485    0.451484   -0.456134
+      5          6           0        0.152336   -0.807514   -0.886089
+      6          6           0        0.641191   -1.603171    0.257902
+      7          8           0        1.628191   -1.288337    0.947137
+      8          1           0       -3.607741    1.169927    1.180873
+      9          1           0       -2.948680    1.961297   -0.260563
+     10          1           0       -2.083546    2.052763    1.284830
+     11          1           0       -1.683279   -0.391490    1.215970
+     12          1           0       -3.545281   -0.873007   -0.133901
+     13          1           0       -0.869639    1.004634   -1.367674
+     14          1           0       -0.000235    1.088755    0.156150
+     15          1           0        1.042433   -0.447333   -1.417517
+     16          1           0       -0.478998   -1.429259   -1.518684
+     17          1           0        0.128471   -2.524030    0.558058
+     18          1           0        2.077666   -0.079634    0.755945
+     19          8           0        2.495006    1.131273    0.488740
+     20          8           0        2.679197    1.074063   -0.793679
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518702   0.000000
+     3  O    2.430640   1.420147   0.000000
+     4  C    2.513573   1.518662   2.365661   0.000000
+     5  C    3.913235   2.569919   2.873301   1.548198   0.000000
+     6  C    4.505235   3.107265   3.552979   2.524200   1.476741
+     7  O    5.097782   3.891251   4.617457   3.184101   2.402094
+     8  H    1.092421   2.162719   2.711781   3.465039   4.724488
+     9  H    1.091445   2.154875   2.695710   2.765893   4.204034
+    10  H    1.091018   2.161899   3.372522   2.771347   4.230040
+    11  H    2.139117   1.101930   2.064660   2.143838   2.821562
+    12  H    2.558718   1.954062   0.958208   3.209636   3.773917
+    13  H    2.740667   2.143269   2.634841   1.090803   2.135472
+    14  H    2.749346   2.152191   3.318951   1.090710   2.169188
+    15  H    4.647776   3.474688   3.849553   2.135644   1.097460
+    16  H    4.195785   2.797080   2.527077   2.166093   1.088727
+    17  H    4.837421   3.379357   3.540645   3.236050   2.243336
+    18  H    4.993021   4.040580   4.993184   3.022273   2.633055
+    19  O    5.191789   4.537832   5.608116   3.343641   3.337237
+    20  O    5.565451   4.823418   5.671308   3.393404   3.151809
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.244320   0.000000
+     8  H    5.157070   5.789014   0.000000
+     9  H    5.085411   5.741638   1.771543   0.000000
+    10  H    4.673823   5.005395   1.764476   1.773432   0.000000
+    11  H    2.790918   3.441284   2.478469   3.052375   2.477766
+    12  H    4.267692   5.301505   2.430249   2.899182   3.565052
+    13  H    3.424289   4.105511   3.744278   2.542304   3.099664
+    14  H    2.769159   2.987975   3.751100   3.102952   2.558010
+    15  H    2.074605   2.577205   5.566981   4.803023   4.829586
+    16  H    2.107446   3.246595   4.881845   4.379277   4.749604
+    17  H    1.095882   1.981787   5.290794   5.500650   5.135002
+    18  H    2.152364   1.303667   5.836593   5.519315   4.705584
+    19  O    3.311661   2.610749   6.141992   5.557348   4.737726
+    20  O    3.525177   3.117048   6.590421   5.722272   5.287890
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.349695   0.000000
+    13  H    3.047358   3.493822   0.000000
+    14  H    2.479310   4.062018   1.756412   0.000000
+    15  H    3.790498   4.782885   2.401399   2.433752   0.000000
+    16  H    3.163162   3.410152   2.469664   3.061809   1.813606
+    17  H    2.874546   4.086702   4.141997   3.637349   3.008470
+    18  H    3.801787   5.747939   3.791043   2.458161   2.435333
+    19  O    4.506188   6.394520   3.844886   2.517668   2.869805
+    20  O    5.021726   6.555191   3.595627   2.842842   2.320090
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.424953   0.000000
+    18  H    3.678581   3.132666   0.000000
+    19  O    4.408035   4.355058   1.308383   0.000000
+    20  O    4.094686   4.612989   2.023411   1.296842   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2639091           0.8062499           0.6989160
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.8583695852 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.8460217438 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9829 LenP2D=   22646.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000637    0.001337   -0.000276
+         Rot=    1.000000    0.000151   -0.000044   -0.000149 Ang=   0.02 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7577 S= 0.5038
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.930782393     A.U. after   21 cycles
+            NFock= 21  Conv=0.61D-08     -V/T= 2.0047
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7554 S= 0.5027
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7554,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15627017D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15463321D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9829 LenP2D=   22646.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000201974    0.000128107   -0.000306852
+      2        6          -0.000287236    0.000211671    0.001110880
+      3        8           0.000877091   -0.000792816    0.000373202
+      4        6           0.000843171   -0.003571594    0.000582684
+      5        6           0.000517019    0.003351891   -0.000790622
+      6        6           0.019771046    0.008548988    0.015965377
+      7        8          -0.019386598    0.000766297   -0.013801253
+      8        1          -0.000064319    0.000084542    0.000038381
+      9        1           0.000011973    0.000034310   -0.000053746
+     10        1           0.000028299    0.000010321    0.000026414
+     11        1          -0.000133464    0.000136735   -0.000180873
+     12        1          -0.000050195    0.000236104   -0.000116228
+     13        1          -0.000548227    0.000342373   -0.000071615
+     14        1          -0.000515205   -0.000114404   -0.000009466
+     15        1          -0.000966518   -0.001170141   -0.001061881
+     16        1           0.000886417   -0.000042030   -0.000676889
+     17        1          -0.000353405   -0.000665508   -0.001855484
+     18        1           0.016627513    0.045083289   -0.006979468
+     19        8          -0.019217874   -0.054801313    0.019381213
+     20        8           0.001758537    0.002223179   -0.011573772
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.054801313 RMS     0.011233971
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Pt  4 Step number   1 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  1.36D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  9.04D-05
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  2.29D-07
+ Maximum DWI energy   std dev =  0.000016178 at pt    34
+ Maximum DWI gradient std dev =  0.064251888 at pt    57
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687016    1.408715    0.643391
+      2          6           0       -1.928947    0.142735    0.284038
+      3          8           0       -2.699659   -0.706987   -0.553109
+      4          6           0       -0.639344    0.451548   -0.456261
+      5          6           0        0.152488   -0.807503   -0.885899
+      6          6           0        0.641067   -1.603293    0.257918
+      7          8           0        1.628221   -1.289136    0.947518
+      8          1           0       -3.607740    1.170092    1.180859
+      9          1           0       -2.948856    1.961304   -0.260713
+     10          1           0       -2.083627    2.052950    1.284683
+     11          1           0       -1.682432   -0.391533    1.215406
+     12          1           0       -3.544595   -0.873772   -0.133113
+     13          1           0       -0.870453    1.006199   -1.367188
+     14          1           0       -0.002103    1.089325    0.157137
+     15          1           0        1.041247   -0.448829   -1.421371
+     16          1           0       -0.479388   -1.427866   -1.519423
+     17          1           0        0.126795   -2.523480    0.558191
+     18          1           0        2.076802   -0.076610    0.756566
+     19          8           0        2.495266    1.131958    0.488038
+     20          8           0        2.679183    1.074304   -0.793231
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518719   0.000000
+     3  O    2.430630   1.420155   0.000000
+     4  C    2.513635   1.518711   2.365688   0.000000
+     5  C    3.913199   2.569840   2.873255   1.548159   0.000000
+     6  C    4.505210   3.107132   3.552686   2.524257   1.476586
+     7  O    5.098250   3.891517   4.617502   3.184718   2.402327
+     8  H    1.092495   2.162890   2.711951   3.465233   4.724583
+     9  H    1.091476   2.155032   2.695806   2.766125   4.204222
+    10  H    1.091042   2.161975   3.372569   2.771521   4.230110
+    11  H    2.139458   1.101661   2.064438   2.143196   2.820540
+    12  H    2.558934   1.953873   0.958191   3.209576   3.773526
+    13  H    2.739406   2.143018   2.635095   1.091255   2.137186
+    14  H    2.747218   2.150549   3.317829   1.090455   2.170202
+    15  H    4.649049   3.475690   3.849013   2.136938   1.097848
+    16  H    4.194946   2.796512   2.526466   2.165201   1.088793
+    17  H    4.836005   3.377860   3.538853   3.235255   2.242907
+    18  H    4.991288   4.039482   4.992714   3.021150   2.633415
+    19  O    5.191991   4.538043   5.608292   3.343716   3.337337
+    20  O    5.565232   4.823193   5.671208   3.393228   3.151821
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.244474   0.000000
+     8  H    5.157116   5.789433   0.000000
+     9  H    5.085556   5.742370   1.771518   0.000000
+    10  H    4.674004   5.006100   1.764408   1.773491   0.000000
+    11  H    2.789945   3.440622   2.479249   3.052638   2.478155
+    12  H    4.266716   5.300784   2.430615   2.899800   3.565147
+    13  H    3.425655   4.107286   3.743280   2.540919   3.098371
+    14  H    2.770201   2.989938   3.749019   3.101339   2.555910
+    15  H    2.076763   2.581141   5.568266   4.803831   4.831819
+    16  H    2.108349   3.247624   4.881341   4.378253   4.748966
+    17  H    1.096077   1.982287   5.289323   5.499411   5.133953
+    18  H    2.154238   1.306868   5.835092   5.517716   4.703520
+    19  O    3.312492   2.612390   6.142323   5.557599   4.738052
+    20  O    3.525388   3.117784   6.590266   5.722340   5.287707
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.349192   0.000000
+    13  H    3.046762   3.494033   0.000000
+    14  H    2.477172   4.060448   1.756277   0.000000
+    15  H    3.791346   4.782273   2.403049   2.438480   0.000000
+    16  H    3.162371   3.409453   2.469976   3.061847   1.811204
+    17  H    2.872357   4.083937   4.142490   3.637282   3.009828
+    18  H    3.800204   5.746920   3.790662   2.457756   2.440150
+    19  O    4.505913   6.394427   3.845223   2.519556   2.873830
+    20  O    5.020657   6.554859   3.596385   2.844771   2.323215
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.425759   0.000000
+    18  H    3.679690   3.135132   0.000000
+    19  O    4.408079   4.356237   1.306850   0.000000
+    20  O    4.094482   4.613576   2.022212   1.295685   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2632158           0.8062815           0.6988600
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       474.8480061374 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      474.8356573067 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22643.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000009    0.000153   -0.000035
+         Rot=    1.000000    0.000012   -0.000006   -0.000013 Ang=   0.00 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7554 S= 0.5027
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.930882502     A.U. after   15 cycles
+            NFock= 15  Conv=0.47D-08     -V/T= 2.0047
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7553 S= 0.5027
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7553,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15663567D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15519872D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22643.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000169861    0.000121254   -0.000234620
+      2        6          -0.000277136    0.000168469    0.000886534
+      3        8           0.000842274   -0.000785174    0.000403453
+      4        6           0.000566394   -0.003309978    0.000477693
+      5        6           0.000487044    0.003652119   -0.001590516
+      6        6           0.020030264    0.008437986    0.016281072
+      7        8          -0.019792945    0.000835960   -0.014094794
+      8        1          -0.000023015    0.000074266    0.000011942
+      9        1           0.000034737    0.000009672   -0.000046313
+     10        1           0.000029671    0.000006550    0.000011340
+     11        1          -0.000180625    0.000096764   -0.000002962
+     12        1          -0.000081498    0.000216468   -0.000131595
+     13        1          -0.000371945    0.000071390    0.000073821
+     14        1          -0.000234348   -0.000089060   -0.000003340
+     15        1          -0.001032595   -0.001149718   -0.000528124
+     16        1           0.000793482   -0.000204357   -0.000426392
+     17        1          -0.000264126   -0.000608437   -0.001900283
+     18        1           0.016946776    0.045233889   -0.007130403
+     19        8          -0.019595838   -0.054984570    0.020574982
+     20        8           0.001953568    0.002206508   -0.012631495
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.054984570 RMS     0.011364867
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =           0.0000085101
+ Magnitude of corrector gradient =     0.0883096832
+ Magnitude of analytic gradient =      0.0880318806
+ Magnitude of difference =             0.0032478769
+ Angle between gradients (degrees)=    2.1029
+ Pt  4 Step number   2 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  1.39D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  9.27D-05
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  2.29D-07
+ Maximum DWI energy   std dev =  0.000012922 at pt    33
+ Maximum DWI gradient std dev =  0.070816620 at pt    57
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence Met
+ Point Number:   4          Path Number:   1
+   CHANGE IN THE REACTION COORDINATE =    0.25104
+   NET REACTION COORDINATE UP TO THIS POINT =    0.98964
+  # OF POINTS ALONG THE PATH =   4
+  # OF STEPS =   2
+
+ Calculating another point on the path.
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687012    1.408726    0.643387
+      2          6           0       -1.929017    0.142748    0.284218
+      3          8           0       -2.699597   -0.707058   -0.553078
+      4          6           0       -0.639271    0.450820   -0.456271
+      5          6           0        0.152432   -0.806675   -0.886282
+      6          6           0        0.644817   -1.602061    0.261132
+      7          8           0        1.625429   -1.288989    0.945511
+      8          1           0       -3.607791    1.170280    1.180899
+      9          1           0       -2.948743    1.961340   -0.260774
+     10          1           0       -2.083556    2.052916    1.284766
+     11          1           0       -1.682995   -0.391356    1.215519
+     12          1           0       -3.544871   -0.873132   -0.133546
+     13          1           0       -0.871360    1.006226   -1.366816
+     14          1           0       -0.002743    1.089053    0.157203
+     15          1           0        1.038661   -0.451757   -1.422585
+     16          1           0       -0.477470   -1.428454   -1.520381
+     17          1           0        0.125731   -2.524677    0.553435
+     18          1           0        2.120090    0.038990    0.738426
+     19          8           0        2.492334    1.123328    0.490783
+     20          8           0        2.679504    1.074704   -0.794674
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518636   0.000000
+     3  O    2.430685   1.420222   0.000000
+     4  C    2.513975   1.518775   2.365375   0.000000
+     5  C    3.912841   2.569806   2.873155   1.546932   0.000000
+     6  C    4.506888   3.109585   3.556554   2.525445   1.480419
+     7  O    5.095693   3.888607   4.614137   3.181320   2.399544
+     8  H    1.092525   2.162901   2.712175   3.465553   4.724497
+     9  H    1.091510   2.155025   2.695898   2.766505   4.203624
+    10  H    1.091104   2.161879   3.372631   2.771981   4.229699
+    11  H    2.139084   1.101416   2.064239   2.143246   2.821143
+    12  H    2.558598   1.953848   0.958163   3.209285   3.773735
+    13  H    2.738524   2.142463   2.634381   1.091528   2.136744
+    14  H    2.746610   2.149921   3.317158   1.090349   2.169499
+    15  H    4.648685   3.474727   3.846530   2.136321   1.094984
+    16  H    4.196851   2.798615   2.528623   2.165683   1.088792
+    17  H    4.836453   3.377814   3.537032   3.233932   2.241657
+    18  H    4.999343   4.075824   5.045191   3.034960   2.688216
+    19  O    5.189447   4.533492   5.603223   3.340079   3.331120
+    20  O    5.565886   4.824004   5.671664   3.393820   3.151836
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.236118   0.000000
+     8  H    5.159121   5.787055   0.000000
+     9  H    5.087621   5.739583   1.771593   0.000000
+    10  H    4.674473   5.003997   1.764406   1.773593   0.000000
+    11  H    2.792019   3.438650   2.478860   3.052334   2.477844
+    12  H    4.270901   5.298047   2.430486   2.899274   3.564942
+    13  H    3.428144   4.104732   3.742435   2.539900   3.097720
+    14  H    2.769879   2.987885   3.748456   3.100727   2.555428
+    15  H    2.076828   2.579366   5.567643   4.803357   4.832326
+    16  H    2.112690   3.243803   4.883569   4.380012   4.750611
+    17  H    1.098231   1.982358   5.290143   5.499062   5.135188
+    18  H    2.257717   1.432167   5.855273   5.512431   4.693082
+    19  O    3.300576   2.603377   6.139217   5.556296   4.736381
+    20  O    3.524166   3.118711   6.591062   5.722616   5.288451
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.349184   0.000000
+    13  H    3.046382   3.492936   0.000000
+    14  H    2.476871   4.059726   1.756130   0.000000
+    15  H    3.790864   4.779952   2.403540   2.440153   0.000000
+    16  H    3.164492   3.411838   2.471113   3.062270   1.806144
+    17  H    2.874179   4.083242   4.141115   3.637657   3.005843
+    18  H    3.856977   5.803799   3.783697   2.438621   2.465824
+    19  O    4.500320   6.389326   3.844324   2.517510   2.873157
+    20  O    5.022112   6.555456   3.597315   2.846177   2.327384
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.422038   0.000000
+    18  H    3.742048   3.253318   0.000000
+    19  O    4.401830   4.348870   1.172894   0.000000
+    20  O    4.093768   4.614617   1.932885   1.299922   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2666602           0.8064108           0.6993322
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.0650223689 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.0526745202 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22646.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.50D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000491    0.001457   -0.000329
+         Rot=    1.000000    0.000142   -0.000053   -0.000152 Ang=   0.02 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7553 S= 0.5026
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.945017848     A.U. after   18 cycles
+            NFock= 18  Conv=0.99D-08     -V/T= 2.0046
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7548 S= 0.5024
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7548,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15405701D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15262831D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22646.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000026948    0.000138595   -0.000256595
+      2        6          -0.000128026    0.000080071    0.001024487
+      3        8           0.000736172   -0.000518970    0.000307593
+      4        6           0.000568107   -0.004117007   -0.000686404
+      5        6          -0.000512539    0.004505175   -0.001487638
+      6        6           0.019077039    0.005046383    0.017305146
+      7        8          -0.020156349   -0.003454777   -0.012582907
+      8        1          -0.000034539    0.000118390    0.000025759
+      9        1           0.000016819    0.000029722   -0.000042552
+     10        1           0.000011701    0.000007559    0.000027553
+     11        1          -0.000100602    0.000055494   -0.000057816
+     12        1          -0.000036292    0.000176793   -0.000060068
+     13        1          -0.000617741    0.000357445    0.000245218
+     14        1          -0.000652988   -0.000007912    0.000286409
+     15        1          -0.001024645   -0.001421591   -0.001519419
+     16        1           0.000718467   -0.000009207   -0.000597424
+     17        1          -0.001150750   -0.000654194   -0.002161072
+     18        1           0.018681419    0.049988127   -0.007748611
+     19        8          -0.017860530   -0.053662086    0.016762888
+     20        8           0.002438331    0.003341989   -0.008784548
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.053662086 RMS     0.011404356
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Pt  5 Step number   1 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  5.60D-05
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  3.74D-05
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  1.04D-07
+ Maximum DWI energy   std dev =  0.000117637 at pt    21
+ Maximum DWI gradient std dev =  0.016110478 at pt    38
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence Met
+ Point Number:   5          Path Number:   1
+   CHANGE IN THE REACTION COORDINATE =    0.25158
+   NET REACTION COORDINATE UP TO THIS POINT =    1.24122
+  # OF POINTS ALONG THE PATH =   5
+  # OF STEPS =   1
+
+ Calculating another point on the path.
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687007    1.408764    0.643307
+      2          6           0       -1.929003    0.142756    0.284413
+      3          8           0       -2.699461   -0.707139   -0.553016
+      4          6           0       -0.639146    0.450002   -0.456499
+      5          6           0        0.152348   -0.805734   -0.886592
+      6          6           0        0.648429   -1.601330    0.264596
+      7          8           0        1.622399   -1.289940    0.943801
+      8          1           0       -3.607845    1.170605    1.180932
+      9          1           0       -2.948715    1.961400   -0.260906
+     10          1           0       -2.083549    2.052973    1.284790
+     11          1           0       -1.683097   -0.391271    1.215412
+     12          1           0       -3.544822   -0.872852   -0.133565
+     13          1           0       -0.872930    1.007245   -1.365953
+     14          1           0       -0.004652    1.089113    0.158137
+     15          1           0        1.035963   -0.455386   -1.426701
+     16          1           0       -0.475966   -1.428304   -1.521662
+     17          1           0        0.122355   -2.525743    0.548179
+     18          1           0        2.164084    0.156009    0.720278
+     19          8           0        2.489959    1.116072    0.493032
+     20          8           0        2.679897    1.075267   -0.795851
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518602   0.000000
+     3  O    2.430717   1.420286   0.000000
+     4  C    2.514465   1.518908   2.364992   0.000000
+     5  C    3.912356   2.569612   2.872944   1.545417   0.000000
+     6  C    4.508794   3.112135   3.560398   2.527012   1.484690
+     7  O    5.093553   3.885855   4.610704   3.178494   2.397050
+     8  H    1.092567   2.163038   2.712501   3.466068   4.724365
+     9  H    1.091558   2.155145   2.696025   2.767073   4.202988
+    10  H    1.091177   2.161843   3.372698   2.772707   4.229224
+    11  H    2.138987   1.101097   2.064003   2.143097   2.821181
+    12  H    2.558349   1.953724   0.958142   3.208922   3.773674
+    13  H    2.736644   2.141574   2.633665   1.091916   2.137258
+    14  H    2.744558   2.148177   3.315759   1.090332   2.169459
+    15  H    4.649785   3.475156   3.844489   2.137056   1.093269
+    16  H    4.198184   2.800259   2.530274   2.165463   1.088891
+    17  H    4.835485   3.376171   3.533072   3.231767   2.240067
+    18  H    5.010829   4.116250   5.101017   3.054396   2.748466
+    19  O    5.187411   4.529690   5.598964   3.337148   3.325828
+    20  O    5.566512   4.824781   5.672163   3.394431   3.151969
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.227559   0.000000
+     8  H    5.161314   5.784978   0.000000
+     9  H    5.090053   5.737387   1.771639   0.000000
+    10  H    4.675299   5.002538   1.764324   1.773718   0.000000
+    11  H    2.793619   3.436231   2.478972   3.052272   2.477801
+    12  H    4.274642   5.294795   2.430554   2.899059   3.564758
+    13  H    3.431892   4.103497   3.740731   2.537799   3.096059
+    14  H    2.770619   2.987383   3.746432   3.099031   2.553465
+    15  H    2.079389   2.580633   5.568533   4.803914   4.834811
+    16  H    2.117763   3.240492   4.885388   4.381105   4.751818
+    17  H    1.100778   1.983395   5.289401   5.497322   5.135489
+    18  H    2.364973   1.560177   5.878501   5.510252   4.686099
+    19  O    3.290546   2.597065   6.136725   5.555374   4.735149
+    20  O    3.523576   3.120721   6.591849   5.722996   5.289177
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.348975   0.000000
+    13  H    3.045597   3.491783   0.000000
+    14  H    2.475186   4.057980   1.755978   0.000000
+    15  H    3.791855   4.778082   2.405588   2.445418   0.000000
+    16  H    3.166098   3.413681   2.472594   3.062882   1.800420
+    17  H    2.874166   4.079830   4.139625   3.638056   3.003533
+    18  H    3.917330   5.863379   3.781589   2.426953   2.501196
+    19  O    4.495366   6.384906   3.844046   2.517134   2.875581
+    20  O    5.023110   6.555984   3.598920   2.849050   2.333108
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.417975   0.000000
+    18  H    3.808701   3.374917   0.000000
+    19  O    4.396538   4.344123   1.039017   0.000000
+    20  O    4.093182   4.616786   1.846550   1.303443   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2685949           0.8064941           0.6996300
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3906274487 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3782750997 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22646.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000496    0.001547   -0.000363
+         Rot=    1.000000    0.000144   -0.000058   -0.000157 Ang=   0.03 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7547 S= 0.5024
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.956475199     A.U. after   18 cycles
+            NFock= 18  Conv=0.42D-08     -V/T= 2.0044
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7544 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7544,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14948000D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.14989355D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22646.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6          -0.000062923    0.000157883   -0.000250647
+      2        6          -0.000007731   -0.000097371    0.000988091
+      3        8           0.000587019   -0.000297233    0.000267820
+      4        6           0.000416410   -0.004296729   -0.001489055
+      5        6          -0.000895783    0.004773128   -0.001544712
+      6        6           0.015317177    0.001628924    0.015764804
+      7        8          -0.017809055   -0.005789288   -0.009814811
+      8        1          -0.000032580    0.000136932    0.000025269
+      9        1           0.000013404    0.000032535   -0.000034715
+     10        1          -0.000002671    0.000007751    0.000029721
+     11        1          -0.000051109    0.000002820   -0.000030104
+     12        1          -0.000007836    0.000129729   -0.000016306
+     13        1          -0.000705657    0.000467601    0.000388672
+     14        1          -0.000860384    0.000010138    0.000448232
+     15        1          -0.001023015   -0.001484435   -0.001897637
+     16        1           0.000545840    0.000051909   -0.000499680
+     17        1          -0.001587766   -0.000458456   -0.002181201
+     18        1           0.009172494    0.021230724   -0.001476142
+     19        8          -0.005668877   -0.019657418    0.007751623
+     20        8           0.002663042    0.003450857   -0.006429222
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.021230724 RMS     0.005879324
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Pt  6 Step number   1 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  1.93D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  1.29D-04
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  8.45D-07
+ Maximum DWI energy   std dev =  0.000422333 at pt    37
+ Maximum DWI gradient std dev =  0.068654874 at pt    -1
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687003    1.408784    0.643272
+      2          6           0       -1.928995    0.142746    0.284481
+      3          8           0       -2.699405   -0.707172   -0.552986
+      4          6           0       -0.639112    0.449700   -0.456599
+      5          6           0        0.152329   -0.805409   -0.886677
+      6          6           0        0.649482   -1.601116    0.265670
+      7          8           0        1.621444   -1.290247    0.943313
+      8          1           0       -3.607860    1.170734    1.180937
+      9          1           0       -2.948705    1.961420   -0.260953
+     10          1           0       -2.083558    2.052997    1.284784
+     11          1           0       -1.683089   -0.391290    1.215421
+     12          1           0       -3.544796   -0.872786   -0.133541
+     13          1           0       -0.873556    1.007679   -1.365539
+     14          1           0       -0.005434    1.089145    0.158552
+     15          1           0        1.035283   -0.456534   -1.428637
+     16          1           0       -0.475575   -1.428274   -1.521941
+     17          1           0        0.121321   -2.525909    0.546352
+     18          1           0        2.164959    0.153825    0.723386
+     19          8           0        2.490036    1.116230    0.493285
+     20          8           0        2.680044    1.075454   -0.796330
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518604   0.000000
+     3  O    2.430732   1.420297   0.000000
+     4  C    2.514640   1.518953   2.364835   0.000000
+     5  C    3.912186   2.569537   2.872871   1.544877   0.000000
+     6  C    4.509347   3.112869   3.561514   2.527448   1.486006
+     7  O    5.092888   3.884990   4.609623   3.177622   2.396295
+     8  H    1.092579   2.163095   2.712621   3.466249   4.724319
+     9  H    1.091567   2.155198   2.696074   2.767272   4.202771
+    10  H    1.091189   2.161841   3.372714   2.772977   4.229057
+    11  H    2.139033   1.101051   2.063963   2.143083   2.821183
+    12  H    2.558282   1.953679   0.958149   3.208790   3.773657
+    13  H    2.735835   2.141174   2.633377   1.092005   2.137531
+    14  H    2.743708   2.147467   3.315195   1.090344   2.169500
+    15  H    4.650551   3.475753   3.844148   2.137689   1.093180
+    16  H    4.198507   2.800660   2.530668   2.165290   1.088937
+    17  H    4.835068   3.375514   3.531692   3.230854   2.239342
+    18  H    5.012272   4.117429   5.102203   3.056587   2.750112
+    19  O    5.187467   4.529802   5.599087   3.337381   3.325939
+    20  O    5.566754   4.825074   5.672340   3.394670   3.152007
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.224969   0.000000
+     8  H    5.161960   5.784334   0.000000
+     9  H    5.090770   5.736711   1.771642   0.000000
+    10  H    4.675537   5.002092   1.764276   1.773744   0.000000
+    11  H    2.794029   3.435420   2.479082   3.052328   2.477847
+    12  H    4.275723   5.293763   2.430597   2.899014   3.564698
+    13  H    3.433118   4.103204   3.739992   2.536922   3.095320
+    14  H    2.770901   2.987321   3.745584   3.098337   2.552647
+    15  H    2.080766   2.581629   5.569260   4.804388   4.836069
+    16  H    2.119241   3.239447   4.885857   4.381380   4.752112
+    17  H    1.101353   1.983636   5.289108   5.496628   5.135480
+    18  H    2.363470   1.558563   5.879532   5.512339   4.687422
+    19  O    3.289897   2.597712   6.136789   5.555459   4.735163
+    20  O    3.523500   3.121462   6.592146   5.723144   5.289473
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.348933   0.000000
+    13  H    3.045293   3.491345   0.000000
+    14  H    2.474507   4.057287   1.755883   0.000000
+    15  H    3.792736   4.777831   2.406568   2.447730   0.000000
+    16  H    3.166477   3.414139   2.473200   3.063085   1.798799
+    17  H    2.874048   4.078662   4.139004   3.638004   3.003036
+    18  H    3.917490   5.864261   3.784871   2.429911   2.505974
+    19  O    4.495450   6.385006   3.844576   2.517966   2.878138
+    20  O    5.023486   6.556185   3.599537   2.850224   2.334959
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.416387   0.000000
+    18  H    3.810112   3.374726   0.000000
+    19  O    4.396645   4.344975   1.041560   0.000000
+    20  O    4.093055   4.617323   1.850473   1.304175   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2682964           0.8064934           0.6996364
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3892874780 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3769357497 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.000020   -0.000034   -0.000002
+         Rot=    1.000000   -0.000014    0.000002    0.000005 Ang=  -0.00 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7544 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.956522183     A.U. after   14 cycles
+            NFock= 14  Conv=0.40D-08     -V/T= 2.0044
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7544 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7544,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14958695D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15000509D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6          -0.000049005    0.000162172   -0.000234731
+      2        6           0.000003780   -0.000183656    0.000893258
+      3        8           0.000534214   -0.000303806    0.000302033
+      4        6           0.000298577   -0.003992782   -0.001439482
+      5        6          -0.000708352    0.004452649   -0.001401079
+      6        6           0.012160949    0.000893834    0.013082684
+      7        8          -0.015103763   -0.005070679   -0.007711672
+      8        1          -0.000026758    0.000127894    0.000017655
+      9        1           0.000020716    0.000025550   -0.000031894
+     10        1          -0.000002845    0.000008523    0.000021062
+     11        1          -0.000060432   -0.000011107    0.000009980
+     12        1          -0.000009770    0.000122916   -0.000028290
+     13        1          -0.000643572    0.000410215    0.000395107
+     14        1          -0.000763909   -0.000005244    0.000401157
+     15        1          -0.000931121   -0.001330633   -0.001742094
+     16        1           0.000464312   -0.000008690   -0.000332692
+     17        1          -0.001288890   -0.000315466   -0.001967166
+     18        1           0.009508410    0.022469031   -0.002299413
+     19        8          -0.005854377   -0.020692796    0.007544374
+     20        8           0.002451836    0.003242073   -0.005478798
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.022469031 RMS     0.005559613
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0000219144
+ Magnitude of corrector gradient =     0.0479414522
+ Magnitude of analytic gradient =      0.0430645795
+ Magnitude of difference =             0.0084234750
+ Angle between gradients (degrees)=    8.6688
+ Pt  6 Step number   2 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.31D-03 Err=  1.00D-04
+      PEZero:  N= 3 I= 2 D=  1.31D-03 Err=  6.72D-05
+      PEZero:  N= 3 I= 1 D=  2.62D-03 Err=  7.07D-07
+ Maximum DWI energy   std dev =  0.000430974 at pt    49
+ Maximum DWI gradient std dev =  0.042024655 at pt    43
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence Met
+ Point Number:   6          Path Number:   1
+   CHANGE IN THE REACTION COORDINATE =    0.25140
+   NET REACTION COORDINATE UP TO THIS POINT =    1.49262
+  # OF POINTS ALONG THE PATH =   6
+  # OF STEPS =   2
+
+ Calculating another point on the path.
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686990    1.408864    0.643294
+      2          6           0       -1.929243    0.141994    0.285310
+      3          8           0       -2.699453   -0.707235   -0.552844
+      4          6           0       -0.639430    0.446095   -0.457857
+      5          6           0        0.151867   -0.802522   -0.887812
+      6          6           0        0.655807   -1.600844    0.273452
+      7          8           0        1.613170   -1.294877    0.940349
+      8          1           0       -3.608163    1.171908    1.180886
+      9          1           0       -2.947855    1.961636   -0.261153
+     10          1           0       -2.083449    2.052815    1.285116
+     11          1           0       -1.685114   -0.391723    1.216789
+     12          1           0       -3.546677   -0.869593   -0.135705
+     13          1           0       -0.879267    1.009472   -1.362136
+     14          1           0       -0.011019    1.087432    0.160884
+     15          1           0        1.029792   -0.465299   -1.441575
+     16          1           0       -0.472937   -1.431209   -1.520929
+     17          1           0        0.111503   -2.526862    0.532103
+     18          1           0        2.215717    0.248238    0.721229
+     19          8           0        2.490948    1.114297    0.496035
+     20          8           0        2.682098    1.077767   -0.799504
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518978   0.000000
+     3  O    2.430798   1.420182   0.000000
+     4  C    2.516338   1.519339   2.362814   0.000000
+     5  C    3.910706   2.568919   2.872509   1.539499   0.000000
+     6  C    4.513249   3.117709   3.569183   2.530299   1.496599
+     7  O    5.088205   3.878448   4.601485   3.171777   2.391650
+     8  H    1.092572   2.163689   2.713439   3.467803   4.723950
+     9  H    1.091619   2.155758   2.696231   2.768462   4.200184
+    10  H    1.091270   2.162089   3.372750   2.775733   4.227435
+    11  H    2.138870   1.100957   2.063985   2.144722   2.823579
+    12  H    2.556809   1.953626   0.958203   3.207320   3.774837
+    13  H    2.729309   2.137533   2.629661   1.092079   2.138117
+    14  H    2.738038   2.142175   3.310274   1.090437   2.167538
+    15  H    4.655495   3.479486   3.841307   2.141178   1.091387
+    16  H    4.201418   2.803265   2.533515   2.163819   1.089250
+    17  H    4.830514   3.368730   3.519890   3.222172   2.234085
+    18  H    5.038815   4.169173   5.166728   3.095360   2.820032
+    19  O    5.188400   4.530768   5.599856   3.340010   3.325737
+    20  O    5.569416   4.828763   5.675224   3.398276   3.153625
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.206197   0.000000
+     8  H    5.166529   5.779723   0.000000
+     9  H    5.095434   5.731617   1.771766   0.000000
+    10  H    4.677201   4.999090   1.763977   1.773827   0.000000
+    11  H    2.798530   3.430857   2.478779   3.052397   2.477722
+    12  H    4.285208   5.287984   2.430004   2.896581   3.563740
+    13  H    3.441708   4.101671   3.733661   2.529395   3.089752
+    14  H    2.772031   2.986797   3.739917   3.093114   2.547710
+    15  H    2.090609   2.588840   5.573901   4.806775   4.844380
+    16  H    2.126650   3.229290   4.889342   4.384479   4.754584
+    17  H    1.104842   1.984806   5.285615   5.489585   5.134032
+    18  H    2.460269   1.671012   5.914560   5.528407   4.696519
+    19  O    3.284703   2.602313   6.137710   5.556248   4.735881
+    20  O    3.525911   3.130357   6.595315   5.724283   5.292144
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.350111   0.000000
+    13  H    3.043615   3.485699   0.000000
+    14  H    2.470916   4.052010   1.754857   0.000000
+    15  H    3.800398   4.776276   2.413662   2.462141   0.000000
+    16  H    3.169385   3.417914   2.479364   3.063563   1.788148
+    17  H    2.873229   4.071215   4.132242   3.635373   2.998117
+    18  H    3.983918   5.932037   3.807731   2.444706   2.567738
+    19  O    4.497451   6.386535   3.849953   2.524458   2.895589
+    20  O    5.029649   6.559762   3.606181   2.859252   2.350197
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.399367   0.000000
+    18  H    3.882869   3.487787   0.000000
+    19  O    4.396858   4.349839   0.936228   0.000000
+    20  O    4.095078   4.623255   1.793951   1.310074   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2654074           0.8060801           0.6993170
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.6726646241 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6603130538 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22643.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000330    0.001187   -0.000317
+         Rot=    1.000000    0.000063   -0.000044   -0.000108 Ang=   0.02 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7544 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.955288284     A.U. after   17 cycles
+            NFock= 17  Conv=0.62D-08     -V/T= 2.0040
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7542 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7542,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15077194D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15136167D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22643.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000167538    0.000111809   -0.000294077
+      2        6          -0.000032717   -0.000692216    0.000566038
+      3        8           0.000001369   -0.000335106    0.000406790
+      4        6          -0.000462346   -0.002022045   -0.000980318
+      5        6           0.000009679    0.001505383   -0.000155144
+      6        6          -0.007300914   -0.004175719   -0.002935787
+      7        8           0.002459106   -0.000971220    0.005468255
+      8        1          -0.000038947    0.000076270    0.000001668
+      9        1           0.000022686    0.000007227   -0.000022599
+     10        1          -0.000005405    0.000014365    0.000003281
+     11        1           0.000047816   -0.000082243   -0.000049309
+     12        1           0.000048832    0.000063617   -0.000036456
+     13        1          -0.000457056    0.000396979    0.000152377
+     14        1          -0.000375610    0.000010416    0.000270425
+     15        1          -0.000330027   -0.000492938   -0.001368485
+     16        1          -0.000098146    0.000066191    0.000101279
+     17        1          -0.000468940   -0.000211191   -0.000595504
+     18        1          -0.014193246   -0.050527855    0.013264451
+     19        8           0.019488809    0.055356559   -0.014059901
+     20        8           0.001517517    0.001901718    0.000263015
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.055356559 RMS     0.010572606
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Pt  7 Step number   1 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  1.30D-03
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  8.61D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  1.45D-05
+      PEZero:  N= 4 I= 3 D=  6.25D-04 Err=  6.43D-04
+      PEZero:  N= 4 I= 2 D=  1.87D-03 Err=  6.78D-06
+      PEZero:  N= 4 I= 1 D=  3.12D-03 Err=  1.03D-06
+ Maximum DWI energy   std dev =  0.000195926 at pt    30
+ Maximum DWI gradient std dev =  1.315646161 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686703    1.409021    0.642798
+      2          6           0       -1.929217    0.141485    0.285695
+      3          8           0       -2.699150   -0.707737   -0.552417
+      4          6           0       -0.639670    0.445139   -0.458077
+      5          6           0        0.152523   -0.802142   -0.888048
+      6          6           0        0.655254   -1.599086    0.273100
+      7          8           0        1.612897   -1.295144    0.942145
+      8          1           0       -3.608153    1.172730    1.180213
+      9          1           0       -2.946966    1.961442   -0.262032
+     10          1           0       -2.083177    2.053099    1.284472
+     11          1           0       -1.686191   -0.391696    1.217969
+     12          1           0       -3.548187   -0.866964   -0.137562
+     13          1           0       -0.881495    1.008975   -1.361383
+     14          1           0       -0.011427    1.086540    0.160606
+     15          1           0        1.029266   -0.466478   -1.445795
+     16          1           0       -0.472751   -1.434053   -1.517664
+     17          1           0        0.113006   -2.526319    0.528745
+     18          1           0        2.208842    0.195636    0.740519
+     19          8           0        2.493450    1.120639    0.494614
+     20          8           0        2.682941    1.079231   -0.800996
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519196   0.000000
+     3  O    2.430918   1.420002   0.000000
+     4  C    2.516215   1.519320   2.362093   0.000000
+     5  C    3.910747   2.569386   2.872909   1.538881   0.000000
+     6  C    4.511548   3.115964   3.567634   2.527905   1.495367
+     7  O    5.088092   3.878325   4.601360   3.172265   2.392770
+     8  H    1.092574   2.163898   2.713752   3.467747   4.724458
+     9  H    1.091615   2.155937   2.696341   2.767891   4.199539
+    10  H    1.091249   2.162297   3.372803   2.775918   4.227363
+    11  H    2.138792   1.101127   2.064034   2.145840   2.825711
+    12  H    2.555626   1.953760   0.958290   3.206839   3.776597
+    13  H    2.726821   2.136147   2.627813   1.091949   2.138548
+    14  H    2.737445   2.141657   3.309334   1.090345   2.166489
+    15  H    4.657053   3.481421   3.841539   2.142890   1.091984
+    16  H    4.201459   2.802805   2.533001   2.163782   1.089356
+    17  H    4.830971   3.368519   3.519144   3.220233   2.231961
+    18  H    5.044622   4.163332   5.155207   3.100468   2.806464
+    19  O    5.190289   4.534575   5.603778   3.343704   3.329981
+    20  O    5.570133   4.830348   5.676438   3.399913   3.154386
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.207097   0.000000
+     8  H    5.165506   5.779830   0.000000
+     9  H    5.093104   5.731295   1.771809   0.000000
+    10  H    4.675503   4.998888   1.763936   1.773755   0.000000
+    11  H    2.798737   3.431658   2.478466   3.052412   2.477709
+    12  H    4.286439   5.290169   2.429090   2.894277   3.563032
+    13  H    3.440220   4.103316   3.731110   2.526249   3.087844
+    14  H    2.769423   2.986914   3.739447   3.092161   2.547441
+    15  H    2.092196   2.594142   5.575712   4.806923   4.846640
+    16  H    2.122844   3.227984   4.889234   4.384945   4.754542
+    17  H    1.104151   1.984027   5.287191   5.488967   5.134725
+    18  H    2.419327   1.618094   5.914852   5.541257   4.708235
+    19  O    3.290127   2.609916   6.140221   5.556760   4.736968
+    20  O    3.526836   3.133878   6.596347   5.724039   5.292775
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.351675   0.000000
+    13  H    3.043431   3.482546   0.000000
+    14  H    2.471443   4.051389   1.754846   0.000000
+    15  H    3.804594   4.777545   2.415594   2.464839   0.000000
+    16  H    3.169012   3.418271   2.481911   3.063136   1.788133
+    17  H    2.875544   4.074525   4.130366   3.633698   2.996879
+    18  H    3.967896   5.919757   3.824879   2.461627   2.570946
+    19  O    4.503309   6.391524   3.853238   2.527278   2.903095
+    20  O    5.032808   6.561613   3.608902   2.860831   2.353640
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.392477   0.000000
+    18  H    3.866034   3.441862   0.000000
+    19  O    4.401597   4.355224   0.998550   0.000000
+    20  O    4.097389   4.623069   1.838961   1.310049   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2626784           0.8057086           0.6989411
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3391678461 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3268253871 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22639.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000475    0.000198    0.000048
+         Rot=    1.000000    0.000107    0.000009   -0.000027 Ang=   0.01 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.958269448     A.U. after   16 cycles
+            NFock= 16  Conv=0.98D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15141111D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15196237D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22639.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000254308    0.000050874   -0.000324535
+      2        6          -0.000109075   -0.000716805    0.000582661
+      3        8          -0.000195490   -0.000493815    0.000435573
+      4        6          -0.000570934   -0.001339466   -0.000624996
+      5        6          -0.000037723    0.001057509   -0.000375517
+      6        6          -0.007196052   -0.004109413   -0.003999584
+      7        8           0.003084144   -0.000324886    0.006087127
+      8        1          -0.000031271    0.000052882   -0.000007874
+      9        1           0.000023195   -0.000000084   -0.000022886
+     10        1           0.000006655    0.000008036   -0.000002113
+     11        1           0.000092447   -0.000074106   -0.000113983
+     12        1           0.000119211    0.000072959   -0.000069848
+     13        1          -0.000271930    0.000315646    0.000021166
+     14        1          -0.000162676    0.000079816    0.000170431
+     15        1          -0.000348073   -0.000302406   -0.000814895
+     16        1          -0.000163577    0.000206973    0.000056446
+     17        1          -0.000345944   -0.000197799   -0.000233352
+     18        1           0.001467817    0.000923566   -0.000949746
+     19        8           0.003304177    0.003221582   -0.001032082
+     20        8           0.001080792    0.001568939    0.001218008
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.007196052 RMS     0.001680565
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0007624076
+ Magnitude of corrector gradient =     0.0087597289
+ Magnitude of analytic gradient =      0.0130176010
+ Magnitude of difference =             0.0138274179
+ Angle between gradients (degrees)=   76.0465
+ Pt  7 Step number   2 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  1.60D-03
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  9.15D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  1.45D-03
+      PEZero:  N= 4 I= 3 D=  6.25D-04 Err=  6.80D-04
+      PEZero:  N= 4 I= 2 D=  1.87D-03 Err=  8.23D-06
+      PEZero:  N= 4 I= 1 D=  3.12D-03 Err=  5.58D-04
+ Maximum DWI energy   std dev =  0.000451230 at pt    37
+ Maximum DWI gradient std dev =  1.445085918 at pt    32
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687582    1.408561    0.643912
+      2          6           0       -1.928366    0.143155    0.284289
+      3          8           0       -2.698951   -0.706959   -0.552750
+      4          6           0       -0.638419    0.447643   -0.457699
+      5          6           0        0.151270   -0.803599   -0.886360
+      6          6           0        0.650206   -1.607468    0.271588
+      7          8           0        1.612371   -1.293851    0.938813
+      8          1           0       -3.607184    1.168608    1.182937
+      9          1           0       -2.952048    1.961010   -0.259570
+     10          1           0       -2.084552    2.053519    1.285184
+     11          1           0       -1.680358   -0.390987    1.214325
+     12          1           0       -3.535042   -0.890234   -0.122613
+     13          1           0       -0.872058    1.009874   -1.364569
+     14          1           0       -0.008820    1.088869    0.160495
+     15          1           0        1.035206   -0.460838   -1.428611
+     16          1           0       -0.473265   -1.422718   -1.528584
+     17          1           0        0.109819   -2.529394    0.546233
+     18          1           0        2.187773    0.207660    0.705083
+     19          8           0        2.488455    1.106982    0.497817
+     20          8           0        2.681663    1.076581   -0.797195
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518878   0.000000
+     3  O    2.430546   1.420256   0.000000
+     4  C    2.517137   1.518955   2.363882   0.000000
+     5  C    3.910814   2.567420   2.871306   1.540443   0.000000
+     6  C    4.513965   3.116709   3.564731   2.532961   1.495321
+     7  O    5.087199   3.876881   4.599642   3.170032   2.388812
+     8  H    1.092608   2.162765   2.712055   3.467714   4.722030
+     9  H    1.091523   2.155993   2.695936   2.771717   4.203155
+    10  H    1.091259   2.162332   3.372792   2.776289   4.228194
+    11  H    2.139683   1.100810   2.063959   2.141169   2.817444
+    12  H    2.567141   1.953169   0.957943   3.208212   3.765595
+    13  H    2.736617   2.141430   2.635167   1.092293   2.136485
+    14  H    2.740741   2.143445   3.312177   1.090746   2.168633
+    15  H    4.652865   3.475859   3.843390   2.137529   1.092184
+    16  H    4.199891   2.802817   2.533426   2.161556   1.088946
+    17  H    4.831406   3.371250   3.523950   3.229627   2.243303
+    18  H    5.021453   4.138095   5.128231   3.065455   2.775371
+    19  O    5.186873   4.525800   5.594931   3.335427   3.320949
+    20  O    5.569182   4.826309   5.673780   3.396139   3.153715
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.212150   0.000000
+     8  H    5.163576   5.776422   0.000000
+     9  H    5.098274   5.732728   1.771420   0.000000
+    10  H    4.680716   4.999210   1.764066   1.774084   0.000000
+    11  H    2.792867   3.425366   2.479109   3.053106   2.478710
+    12  H    4.264519   5.271185   2.438954   2.913457   3.570924
+    13  H    3.441623   4.096963   3.741109   2.540087   3.095243
+    14  H    2.777928   2.985196   3.741653   3.098335   2.550321
+    15  H    2.086543   2.575214   5.570194   4.809387   4.839377
+    16  H    2.130008   3.233347   4.887614   4.382280   4.753711
+    17  H    1.103357   1.984527   5.281735   5.494368   5.134628
+    18  H    2.417999   1.624885   5.893496   5.515665   4.690040
+    19  O    3.286119   2.593453   6.134330   5.558964   4.735850
+    20  O    3.531746   3.126669   6.593859   5.727997   5.292212
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.340194   0.000000
+    13  H    3.044085   3.499193   0.000000
+    14  H    2.468718   4.053546   1.754205   0.000000
+    15  H    3.790024   4.772545   2.409305   2.452924   0.000000
+    16  H    3.169400   3.410978   2.470515   3.062150   1.791841
+    17  H    2.867728   4.052063   4.140249   3.640699   3.005873
+    18  H    3.947170   5.885666   3.780155   2.428606   2.515542
+    19  O    4.487349   6.376231   3.843300   2.520019   2.877693
+    20  O    5.022668   6.555215   3.599346   2.855874   2.339479
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.422722   0.000000
+    18  H    3.837776   3.440144   0.000000
+    19  O    4.390611   4.345513   0.970643   0.000000
+    20  O    4.090843   4.628416   1.804380   1.309698   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2673177           0.8070970           0.6999917
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.7061177040 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6937587751 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9827 LenP2D=   22653.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.001998   -0.003932    0.000785
+         Rot=    1.000000   -0.000492    0.000064    0.000335 Ang=  -0.07 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957385107     A.U. after   16 cycles
+            NFock= 16  Conv=0.78D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14946829D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.14996735D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9827 LenP2D=   22653.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000031520    0.000009404   -0.000098794
+      2        6           0.000069176   -0.000469515    0.000523398
+      3        8           0.000459043   -0.000366894    0.000344950
+      4        6          -0.000125259   -0.002234997   -0.000836762
+      5        6           0.000219539    0.001455062   -0.000634907
+      6        6          -0.001478734    0.000053538    0.002135968
+      7        8          -0.003242444   -0.003801753    0.001359012
+      8        1          -0.000026636    0.000150511   -0.000014756
+      9        1           0.000085560   -0.000008542   -0.000072587
+     10        1           0.000021980    0.000019947   -0.000019642
+     11        1          -0.000189063   -0.000044849    0.000170241
+     12        1          -0.000267654    0.000124234   -0.000023051
+     13        1          -0.000758015    0.000274399    0.000367057
+     14        1          -0.000625959   -0.000200035    0.000291134
+     15        1          -0.000702184   -0.001021583   -0.001700996
+     16        1           0.000175584   -0.000388681    0.000067708
+     17        1          -0.000742575   -0.000419828   -0.001668456
+     18        1          -0.004434725   -0.019000607    0.007956982
+     19        8           0.009357494    0.022291683   -0.006881884
+     20        8           0.002173353    0.003578507   -0.001264615
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.022291683 RMS     0.004373051
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0012699882
+ Magnitude of corrector gradient =     0.0042882068
+ Magnitude of analytic gradient =      0.0338735079
+ Magnitude of difference =             0.0354288896
+ Angle between gradients (degrees)=  107.9232
+ Pt  7 Step number   3 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  7.59D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  5.02D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  6.01D-06
+ Maximum DWI energy   std dev =  0.000473823 at pt    -1
+ Maximum DWI gradient std dev =  1.376626908 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686447    1.409218    0.642362
+      2          6           0       -1.929491    0.141440    0.285777
+      3          8           0       -2.699435   -0.707681   -0.552673
+      4          6           0       -0.639959    0.445887   -0.458081
+      5          6           0        0.152573   -0.801941   -0.888267
+      6          6           0        0.656704   -1.596967    0.272353
+      7          8           0        1.617621   -1.292751    0.944033
+      8          1           0       -3.608672    1.174004    1.178994
+      9          1           0       -2.945117    1.961977   -0.262760
+     10          1           0       -2.082773    2.052706    1.284493
+     11          1           0       -1.686697   -0.391984    1.217811
+     12          1           0       -3.554627   -0.854705   -0.144644
+     13          1           0       -0.881975    1.008831   -1.362065
+     14          1           0       -0.010592    1.087454    0.159614
+     15          1           0        1.028155   -0.464578   -1.446134
+     16          1           0       -0.473825   -1.434682   -1.516233
+     17          1           0        0.120465   -2.527684    0.527506
+     18          1           0        2.203929    0.216095    0.741219
+     19          8           0        2.493708    1.122853    0.492147
+     20          8           0        2.682279    1.079185   -0.800389
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519012   0.000000
+     3  O    2.430955   1.420148   0.000000
+     4  C    2.515372   1.519508   2.362437   0.000000
+     5  C    3.910510   2.569696   2.873232   1.539559   0.000000
+     6  C    4.511177   3.116190   3.568637   2.527473   1.494407
+     7  O    5.090840   3.882294   4.606453   3.175761   2.396786
+     8  H    1.092611   2.164180   2.714060   3.467481   4.724923
+     9  H    1.091650   2.155632   2.696569   2.765942   4.198356
+    10  H    1.091252   2.161913   3.372712   2.774913   4.226898
+    11  H    2.138918   1.100989   2.063956   2.146230   2.826048
+    12  H    2.549209   1.954133   0.958883   3.207035   3.781414
+    13  H    2.726566   2.136596   2.627678   1.092091   2.138614
+    14  H    2.738024   2.143136   3.310550   1.090531   2.166678
+    15  H    4.655233   3.480580   3.840872   2.141914   1.091637
+    16  H    4.200357   2.801850   2.531860   2.164215   1.089531
+    17  H    4.836440   3.374163   3.525767   3.223624   2.232405
+    18  H    5.034789   4.159106   5.154658   3.094968   2.810638
+    19  O    5.190238   4.535466   5.604573   3.343813   3.330359
+    20  O    5.568992   4.829860   5.676011   3.399339   3.153691
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.211224   0.000000
+     8  H    5.166596   5.783963   0.000000
+     9  H    5.091714   5.733079   1.771966   0.000000
+    10  H    4.674321   5.000091   1.763977   1.773658   0.000000
+    11  H    2.799537   3.435820   2.479478   3.052351   2.477464
+    12  H    4.296528   5.303702   2.422932   2.884294   3.558346
+    13  H    3.439336   4.106501   3.730837   2.524583   3.088019
+    14  H    2.768413   2.988607   3.740695   3.091056   2.547743
+    15  H    2.091285   2.597352   5.574622   4.803689   4.844678
+    16  H    2.122138   3.232213   4.888431   4.383580   4.753383
+    17  H    1.104033   1.984951   5.294657   5.493576   5.138799
+    18  H    2.429184   1.631413   5.907247   5.528902   4.695115
+    19  O    3.289425   2.608999   6.141125   5.554713   4.736731
+    20  O    3.523566   3.130909   6.595681   5.721534   5.291521
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.357871   0.000000
+    13  H    3.043948   3.478211   0.000000
+    14  H    2.473428   4.052744   1.755277   0.000000
+    15  H    3.804246   4.779954   2.413834   2.462971   0.000000
+    16  H    3.167534   3.421837   2.482158   3.063368   1.789402
+    17  H    2.881592   4.093525   4.133074   3.636172   2.995923
+    18  H    3.966595   5.923879   3.817727   2.449824   2.574932
+    19  O    4.505231   6.395201   3.853095   2.526530   2.902536
+    20  O    5.032437   6.562692   3.608924   2.858886   2.352938
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.392635   0.000000
+    18  H    3.871889   3.451785   0.000000
+    19  O    4.402367   4.354303   0.983981   0.000000
+    20  O    4.097921   4.619058   1.830382   1.306949   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2636796           0.8053582           0.6987647
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3452414349 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3328988025 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22637.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.002907    0.006340   -0.001308
+         Rot=    1.000000    0.000748   -0.000096   -0.000529 Ang=   0.11 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.958124653     A.U. after   16 cycles
+            NFock= 16  Conv=0.41D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15164650D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15217557D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22637.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000217578    0.000119105   -0.000308531
+      2        6          -0.000063750   -0.000584892    0.000431885
+      3        8          -0.000667930   -0.000438122    0.000681935
+      4        6          -0.000428221   -0.001662288   -0.000837401
+      5        6          -0.000441515    0.001616751   -0.000030625
+      6        6          -0.001432256   -0.003817877    0.000103429
+      7        8          -0.002616067   -0.001348093    0.002110906
+      8        1          -0.000013518    0.000042071   -0.000000514
+      9        1          -0.000000119    0.000005524   -0.000003609
+     10        1          -0.000022194    0.000011464    0.000007638
+     11        1           0.000113995   -0.000083168   -0.000065628
+     12        1           0.000702405    0.000088544   -0.000282699
+     13        1          -0.000304983    0.000317872    0.000150148
+     14        1          -0.000404502    0.000029077    0.000184810
+     15        1          -0.000194373   -0.000430966   -0.001033957
+     16        1           0.000021967    0.000297318    0.000057178
+     17        1          -0.000660735    0.000020130   -0.000385022
+     18        1          -0.001212856   -0.009521035    0.001200539
+     19        8           0.006016209    0.014265115   -0.000520833
+     20        8           0.001390866    0.001073471   -0.001459649
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.014265115 RMS     0.002515744
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0006807003
+ Magnitude of corrector gradient =     0.0081875211
+ Magnitude of analytic gradient =      0.0194868671
+ Magnitude of difference =             0.0154522103
+ Angle between gradients (degrees)=   49.3191
+ Pt  7 Step number   4 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  6.75D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  4.47D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  8.86D-06
+ Maximum DWI energy   std dev =  0.000454723 at pt    41
+ Maximum DWI gradient std dev =  1.346183974 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687384    1.408570    0.643755
+      2          6           0       -1.928600    0.142593    0.284724
+      3          8           0       -2.698901   -0.707408   -0.552492
+      4          6           0       -0.638632    0.447074   -0.457292
+      5          6           0        0.152118   -0.803527   -0.887209
+      6          6           0        0.652214   -1.603686    0.272081
+      7          8           0        1.610679   -1.296018    0.938713
+      8          1           0       -3.606903    1.169039    1.183055
+      9          1           0       -2.951967    1.960487   -0.259996
+     10          1           0       -2.084156    2.053801    1.284542
+     11          1           0       -1.681759   -0.391052    1.215506
+     12          1           0       -3.532705   -0.895603   -0.120202
+     13          1           0       -0.873982    1.009863   -1.363162
+     14          1           0       -0.009468    1.087841    0.161376
+     15          1           0        1.034096   -0.462426   -1.433555
+     16          1           0       -0.473269   -1.426086   -1.525279
+     17          1           0        0.104453   -2.522153    0.546009
+     18          1           0        2.198831    0.198913    0.706629
+     19          8           0        2.488167    1.107090    0.499009
+     20          8           0        2.681682    1.076602   -0.798927
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518997   0.000000
+     3  O    2.430741   1.420140   0.000000
+     4  C    2.516776   1.518984   2.363599   0.000000
+     5  C    3.911521   2.568649   2.872208   1.540818   0.000000
+     6  C    4.512731   3.116128   3.565558   2.530590   1.494758
+     7  O    5.086761   3.876055   4.598111   3.169637   2.388292
+     8  H    1.092582   2.162704   2.712498   3.467363   4.723055
+     9  H    1.091505   2.156093   2.695786   2.771437   4.203393
+    10  H    1.091245   2.162533   3.372964   2.775806   4.228682
+    11  H    2.139350   1.100937   2.064092   2.142154   2.820399
+    12  H    2.570489   1.953195   0.957874   3.208126   3.764930
+    13  H    2.734064   2.140071   2.633730   1.092118   2.137241
+    14  H    2.739852   2.142843   3.311431   1.090495   2.168620
+    15  H    4.654595   3.477945   3.843378   2.139696   1.092122
+    16  H    4.200272   2.802652   2.533032   2.162561   1.088954
+    17  H    4.822290   3.361911   3.515507   3.221040   2.238316
+    18  H    5.034115   4.149321   5.137565   3.076929   2.781050
+    19  O    5.186345   4.525926   5.594974   3.335717   3.321022
+    20  O    5.569417   4.827150   5.673984   3.396691   3.152995
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.207358   0.000000
+     8  H    5.163135   5.775757   0.000000
+     9  H    5.096720   5.732318   1.771364   0.000000
+    10  H    4.678677   4.999270   1.764047   1.774092   0.000000
+    11  H    2.794273   3.425744   2.478128   3.052912   2.478709
+    12  H    4.262490   5.266501   2.442689   2.917885   3.573596
+    13  H    3.440049   4.097470   3.738638   2.537455   3.092679
+    14  H    2.773878   2.985283   3.740583   3.097961   2.549296
+    15  H    2.087464   2.579725   5.572001   4.810036   4.841792
+    16  H    2.128087   3.229708   4.887680   4.383350   4.753911
+    17  H    1.103929   1.981499   5.273034   5.485017   5.125895
+    18  H    2.414585   1.623147   5.905478   5.528854   4.703038
+    19  O    3.281848   2.595815   6.133649   5.558726   4.734920
+    20  O    3.528420   3.129820   6.594172   5.727975   5.292351
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.337668   0.000000
+    13  H    3.043780   3.499223   0.000000
+    14  H    2.468779   4.052966   1.754332   0.000000
+    15  H    3.794534   4.771605   2.411089   2.456860   0.000000
+    16  H    3.169172   3.408197   2.474005   3.062637   1.791424
+    17  H    2.860135   4.039606   4.132482   3.632213   3.004228
+    18  H    3.958029   5.893396   3.792605   2.442146   2.524751
+    19  O    4.488439   6.375352   3.844630   2.520427   2.883142
+    20  O    5.025094   6.555065   3.600773   2.857377   2.342200
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.413578   0.000000
+    18  H    3.842154   3.437502   0.000000
+    19  O    4.391449   4.342316   0.975503   0.000000
+    20  O    4.092035   4.626230   1.808365   1.312637   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2672642           0.8070559           0.7001049
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.7095371631 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6971783243 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22653.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.002809   -0.006760    0.001378
+         Rot=    1.000000   -0.000719    0.000053    0.000529 Ang=  -0.10 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957602464     A.U. after   16 cycles
+            NFock= 16  Conv=0.67D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14976935D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15029565D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9828 LenP2D=   22653.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6          -0.000004767   -0.000040506   -0.000125351
+      2        6           0.000119331   -0.000546544    0.000662088
+      3        8           0.000455146   -0.000411385    0.000318020
+      4        6          -0.000133182   -0.002319939   -0.001005606
+      5        6           0.000308540    0.001950891   -0.000756611
+      6        6          -0.007869467   -0.002834356   -0.001348506
+      7        8           0.002999343   -0.001493712    0.005044947
+      8        1          -0.000041948    0.000153858   -0.000016237
+      9        1           0.000087521   -0.000002117   -0.000080852
+     10        1           0.000040730    0.000014999   -0.000016828
+     11        1          -0.000133222   -0.000051115    0.000054175
+     12        1          -0.000342408    0.000142251    0.000002722
+     13        1          -0.000660180    0.000335521    0.000239775
+     14        1          -0.000454768   -0.000081108    0.000293423
+     15        1          -0.000733105   -0.000797239   -0.001612926
+     16        1           0.000124780   -0.000267165    0.000027078
+     17        1          -0.000591684   -0.000551247   -0.001479562
+     18        1          -0.003333631   -0.014881455    0.007076713
+     19        8           0.008386031    0.017933505   -0.008641775
+     20        8           0.001776943    0.003746866    0.001365313
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.017933505 RMS     0.003865944
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0011743309
+ Magnitude of corrector gradient =     0.0073371479
+ Magnitude of analytic gradient =      0.0299454748
+ Magnitude of difference =             0.0339031684
+ Angle between gradients (degrees)=  116.9068
+ Pt  7 Step number   5 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  6.95D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  4.59D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  6.31D-06
+ Maximum DWI energy   std dev =  0.000482161 at pt    -1
+ Maximum DWI gradient std dev =  1.328420927 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686619    1.409215    0.642521
+      2          6           0       -1.929308    0.141895    0.285479
+      3          8           0       -2.699459   -0.707281   -0.552888
+      4          6           0       -0.639766    0.446153   -0.458415
+      5          6           0        0.151901   -0.802170   -0.887541
+      6          6           0        0.654985   -1.600030    0.271873
+      7          8           0        1.618862   -1.291042    0.944102
+      8          1           0       -3.608938    1.173615    1.178863
+      9          1           0       -2.945090    1.962492   -0.262361
+     10          1           0       -2.083159    2.052424    1.285153
+     11          1           0       -1.686021   -0.391823    1.217123
+     12          1           0       -3.557096   -0.849037   -0.147501
+     13          1           0       -0.880862    1.008361   -1.363192
+     14          1           0       -0.009963    1.087978    0.158801
+     15          1           0        1.029322   -0.463917   -1.442108
+     16          1           0       -0.473162   -1.432768   -1.518834
+     17          1           0        0.124739   -2.534236    0.525890
+     18          1           0        2.198853    0.223723    0.741274
+     19          8           0        2.493864    1.122679    0.491287
+     20          8           0        2.682292    1.079079   -0.798847
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518914   0.000000
+     3  O    2.430786   1.420243   0.000000
+     4  C    2.515781   1.519496   2.362556   0.000000
+     5  C    3.910051   2.568786   2.872499   1.539219   0.000000
+     6  C    4.512122   3.116578   3.567846   2.529143   1.494629
+     7  O    5.091120   3.882860   4.607565   3.175894   2.397058
+     8  H    1.092631   2.164194   2.713647   3.467832   4.724156
+     9  H    1.091666   2.155577   2.696744   2.766268   4.198280
+    10  H    1.091265   2.161745   3.372565   2.775521   4.226676
+    11  H    2.138948   1.100911   2.063858   2.145759   2.824173
+    12  H    2.545892   1.954255   0.959153   3.207023   3.782395
+    13  H    2.728429   2.137315   2.628178   1.092166   2.137958
+    14  H    2.738917   2.143596   3.311019   1.090664   2.166492
+    15  H    4.654301   3.479231   3.841060   2.140499   1.091708
+    16  H    4.200917   2.802760   2.532939   2.163929   1.089444
+    17  H    4.844392   3.382097   3.532367   3.230486   2.235750
+    18  H    5.028218   4.154053   5.151222   3.089740   2.809895
+    19  O    5.190604   4.535277   5.604432   3.343540   3.330315
+    20  O    5.568818   4.829174   5.675810   3.398906   3.154337
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.215082   0.000000
+     8  H    5.166892   5.784422   0.000000
+     9  H    5.092888   5.733297   1.772046   0.000000
+    10  H    4.675958   5.000004   1.763974   1.773644   0.000000
+    11  H    2.798852   3.435897   2.479852   3.052363   2.477234
+    12  H    4.299010   5.308249   2.419307   2.879659   3.555765
+    13  H    3.440344   4.106030   3.732525   2.526505   3.090197
+    14  H    2.771340   2.988228   3.741721   3.091459   2.548915
+    15  H    2.090122   2.593394   5.573549   4.803666   4.843290
+    16  H    2.123046   3.234610   4.889160   4.383713   4.754050
+    17  H    1.103824   1.988175   5.302346   5.501431   5.146722
+    18  H    2.435147   1.634639   5.901204   5.521843   4.687811
+    19  O    3.292835   2.607052   6.141623   5.554771   4.737487
+    20  O    3.526193   3.128295   6.595441   5.721508   5.291500
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.360543   0.000000
+    13  H    3.044146   3.477076   0.000000
+    14  H    2.473667   4.053147   1.755354   0.000000
+    15  H    3.801289   4.781166   2.413013   2.459960   0.000000
+    16  H    3.168604   3.425192   2.479829   3.063196   1.789417
+    17  H    2.889047   4.104784   4.138824   3.643259   2.996249
+    18  H    3.962017   5.922135   3.811703   2.442351   2.570567
+    19  O    4.504663   6.396079   3.852393   2.526044   2.898308
+    20  O    5.030889   6.562914   3.608262   2.857517   2.350944
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.398252   0.000000
+    18  H    3.871914   3.457555   0.000000
+    19  O    4.401606   4.357406   0.978594   0.000000
+    20  O    4.096907   4.620828   1.826833   1.304550   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2637474           0.8053788           0.6986641
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3424901070 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3301486345 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9824 LenP2D=   22637.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.002758    0.006979   -0.001421
+         Rot=    1.000000    0.000673   -0.000005   -0.000515 Ang=   0.10 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957935057     A.U. after   16 cycles
+            NFock= 16  Conv=0.65D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15139125D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15190460D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9824 LenP2D=   22637.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000264233    0.000175701   -0.000306715
+      2        6          -0.000122957   -0.000558255    0.000355508
+      3        8          -0.000883309   -0.000429712    0.000786051
+      4        6          -0.000466535   -0.001644007   -0.000724897
+      5        6          -0.000456866    0.001269051    0.000035808
+      6        6           0.003712431   -0.001667543    0.002850592
+      7        8          -0.007621133   -0.003314024   -0.000760279
+      8        1          -0.000003778    0.000038631   -0.000000729
+      9        1          -0.000005535    0.000003833    0.000002567
+     10        1          -0.000036832    0.000015114    0.000003435
+     11        1           0.000101865   -0.000087591   -0.000003725
+     12        1           0.000963365    0.000089917   -0.000386610
+     13        1          -0.000358307    0.000316239    0.000224534
+     14        1          -0.000513277   -0.000032495    0.000187904
+     15        1          -0.000198535   -0.000561574   -0.001093279
+     16        1          -0.000032625    0.000231656    0.000055128
+     17        1          -0.000674544    0.000249590   -0.000422255
+     18        1          -0.002399149   -0.013745791    0.002074391
+     19        8           0.007084864    0.018851684    0.000736679
+     20        8           0.001646625    0.000799576   -0.003614107
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.018851684 RMS     0.003481760
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0009252999
+ Magnitude of corrector gradient =     0.0086415046
+ Magnitude of analytic gradient =      0.0269696003
+ Magnitude of difference =             0.0223507721
+ Angle between gradients (degrees)=   49.5388
+ Pt  7 Step number   6 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  5.41D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.60D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  6.34D-06
+ Maximum DWI energy   std dev =  0.000420021 at pt    39
+ Maximum DWI gradient std dev =  1.313475303 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687172    1.408656    0.643481
+      2          6           0       -1.928816    0.142248    0.284970
+      3          8           0       -2.698973   -0.707667   -0.552413
+      4          6           0       -0.638861    0.447068   -0.457058
+      5          6           0        0.152491   -0.803197   -0.887767
+      6          6           0        0.654126   -1.600994    0.272418
+      7          8           0        1.610765   -1.296511    0.938953
+      8          1           0       -3.606934    1.170021    1.182703
+      9          1           0       -2.951184    1.960213   -0.260671
+     10          1           0       -2.083622    2.053931    1.283908
+     11          1           0       -1.682630   -0.391288    1.216054
+     12          1           0       -3.532856   -0.895952   -0.120421
+     13          1           0       -0.875430    1.010449   -1.362179
+     14          1           0       -0.010060    1.087701    0.161969
+     15          1           0        1.032092   -0.463095   -1.438247
+     16          1           0       -0.474568   -1.428161   -1.521988
+     17          1           0        0.102102   -2.516824    0.547011
+     18          1           0        2.203683    0.197742    0.708580
+     19          8           0        2.488203    1.108129    0.499035
+     20          8           0        2.681502    1.076639   -0.800014
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519020   0.000000
+     3  O    2.430869   1.420108   0.000000
+     4  C    2.516231   1.519048   2.363592   0.000000
+     5  C    3.911611   2.569245   2.872705   1.541075   0.000000
+     6  C    4.512200   3.116190   3.566742   2.529527   1.494706
+     7  O    5.086993   3.876385   4.598342   3.170131   2.388897
+     8  H    1.092551   2.162942   2.713067   3.467122   4.723739
+     9  H    1.091517   2.155912   2.695609   2.770382   4.202676
+    10  H    1.091238   2.162492   3.373004   2.774943   4.228423
+    11  H    2.139332   1.100994   2.064104   2.142802   2.821950
+    12  H    2.570981   1.953240   0.957826   3.208152   3.765529
+    13  H    2.731968   2.139275   2.633050   1.092066   2.137991
+    14  H    2.738941   2.142577   3.311184   1.090411   2.168839
+    15  H    4.655102   3.478922   3.842573   2.140844   1.091969
+    16  H    4.199095   2.801092   2.531237   2.162764   1.089045
+    17  H    4.816507   3.356182   3.511097   3.215872   2.235541
+    18  H    5.038950   4.154525   5.142558   3.082358   2.785245
+    19  O    5.186106   4.526457   5.595485   3.336112   3.321436
+    20  O    5.569253   4.827558   5.674026   3.396879   3.152362
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.205047   0.000000
+     8  H    5.163697   5.776467   0.000000
+     9  H    5.095551   5.732079   1.771366   0.000000
+    10  H    4.677269   4.999295   1.764091   1.774027   0.000000
+    11  H    2.795400   3.426757   2.478254   3.052786   2.478809
+    12  H    4.264062   5.266836   2.443740   2.918166   3.574105
+    13  H    3.439634   4.098590   3.736710   2.534586   3.090366
+    14  H    2.771718   2.985841   3.739810   3.096791   2.547942
+    15  H    2.089030   2.584671   5.572882   4.808908   4.842853
+    16  H    2.126903   3.228340   4.886473   4.382422   4.752585
+    17  H    1.104028   1.979608   5.268195   5.478938   5.119785
+    18  H    2.413879   1.624012   5.910447   5.533390   4.707167
+    19  O    3.279411   2.597252   6.133671   5.557890   4.734148
+    20  O    3.525633   3.130867   6.594264   5.727020   5.291903
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.337560   0.000000
+    13  H    3.043637   3.498320   0.000000
+    14  H    2.469007   4.052742   1.754383   0.000000
+    15  H    3.797392   4.771036   2.411589   2.460029   0.000000
+    16  H    3.167237   3.405989   2.476499   3.062848   1.791197
+    17  H    2.854958   4.035543   4.128224   3.626767   3.003986
+    18  H    3.963321   5.898414   3.798615   2.447748   2.533416
+    19  O    4.489790   6.375988   3.845477   2.520982   2.888264
+    20  O    5.026429   6.555244   3.601691   2.858328   2.344926
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.408006   0.000000
+    18  H    3.846039   3.436803   0.000000
+    19  O    4.392643   4.340053   0.976558   0.000000
+    20  O    4.093415   4.623934   1.810146   1.313729   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2674203           0.8069335           0.7001177
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.7073678664 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6950083118 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22651.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.002538   -0.006412    0.001294
+         Rot=    1.000000   -0.000555   -0.000042    0.000461 Ang=  -0.08 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957629632     A.U. after   16 cycles
+            NFock= 16  Conv=0.99D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15003061D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15056919D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22651.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6          -0.000009617   -0.000035046   -0.000165480
+      2        6           0.000135669   -0.000582890    0.000725237
+      3        8           0.000476227   -0.000399681    0.000289162
+      4        6          -0.000125837   -0.002383129   -0.001052187
+      5        6           0.000242224    0.002134860   -0.000775436
+      6        6          -0.011051750   -0.004111311   -0.002976985
+      7        8           0.006050390   -0.000269869    0.006733294
+      8        1          -0.000048984    0.000135708   -0.000007943
+      9        1           0.000073270    0.000005557   -0.000069934
+     10        1           0.000036626    0.000013641   -0.000003915
+     11        1          -0.000105213   -0.000040764    0.000001595
+     12        1          -0.000380327    0.000138808    0.000033699
+     13        1          -0.000585052    0.000323646    0.000173889
+     14        1          -0.000378077   -0.000040630    0.000281811
+     15        1          -0.000648818   -0.000701716   -0.001518263
+     16        1           0.000157763   -0.000174514   -0.000005196
+     17        1          -0.000570017   -0.000760158   -0.001424516
+     18        1          -0.003096675   -0.013965578    0.006695230
+     19        8           0.008237482    0.017005813   -0.009356289
+     20        8           0.001590716    0.003707254    0.002422227
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.017005813 RMS     0.004013794
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0012291735
+ Magnitude of corrector gradient =     0.0085933264
+ Magnitude of analytic gradient =      0.0310907122
+ Magnitude of difference =             0.0363245579
+ Angle between gradients (degrees)=  121.4750
+ Pt  7 Step number   7 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  6.81D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  4.49D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  6.77D-06
+ Maximum DWI energy   std dev =  0.000464192 at pt    -1
+ Maximum DWI gradient std dev =  1.310164916 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686752    1.409153    0.642704
+      2          6           0       -1.929174    0.142102    0.285338
+      3          8           0       -2.699418   -0.707114   -0.552939
+      4          6           0       -0.639632    0.446072   -0.458608
+      5          6           0        0.151744   -0.802379   -0.887188
+      6          6           0        0.653878   -1.601677    0.271754
+      7          8           0        1.618800   -1.290743    0.943974
+      8          1           0       -3.608934    1.172926    1.179048
+      9          1           0       -2.945551    1.962738   -0.261886
+     10          1           0       -2.083553    2.052282    1.285670
+     11          1           0       -1.685542   -0.391674    1.216823
+     12          1           0       -3.557486   -0.847801   -0.147958
+     13          1           0       -0.880078    1.007804   -1.363884
+     14          1           0       -0.009576    1.088031    0.158293
+     15          1           0        1.030875   -0.463381   -1.438834
+     16          1           0       -0.471835   -1.431552   -1.521236
+     17          1           0        0.127257   -2.538541    0.523976
+     18          1           0        2.196143    0.226044    0.740285
+     19          8           0        2.493893    1.122159    0.491264
+     20          8           0        2.682436    1.079073   -0.798173
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518899   0.000000
+     3  O    2.430700   1.420264   0.000000
+     4  C    2.516170   1.519464   2.362510   0.000000
+     5  C    3.910051   2.568478   2.872268   1.539021   0.000000
+     6  C    4.512484   3.116586   3.567206   2.529797   1.494711
+     7  O    5.090971   3.882649   4.607426   3.175575   2.396645
+     8  H    1.092651   2.164003   2.713216   3.467994   4.723754
+     9  H    1.091658   2.155735   2.696924   2.766991   4.198822
+    10  H    1.091270   2.161778   3.372541   2.776206   4.226932
+    11  H    2.138928   1.100880   2.063856   2.145417   2.823324
+    12  H    2.545027   1.954240   0.959210   3.206944   3.782448
+    13  H    2.729752   2.137750   2.628416   1.092191   2.137441
+    14  H    2.739534   2.143777   3.311139   1.090710   2.166265
+    15  H    4.654024   3.478688   3.841784   2.139753   1.091836
+    16  H    4.202154   2.804270   2.534667   2.163979   1.089369
+    17  H    4.849436   3.386990   3.536094   3.234425   2.237463
+    18  H    5.025131   4.151176   5.148760   3.086645   2.808183
+    19  O    5.190798   4.535024   5.604202   3.343401   3.330111
+    20  O    5.568955   4.828960   5.675822   3.398842   3.154709
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.216402   0.000000
+     8  H    5.166543   5.783954   0.000000
+     9  H    5.093694   5.733458   1.772053   0.000000
+    10  H    4.676855   4.999999   1.763922   1.773693   0.000000
+    11  H    2.798241   3.435323   2.479684   3.052451   2.477109
+    12  H    4.298846   5.308715   2.418042   2.878641   3.555031
+    13  H    3.440599   4.105352   3.733687   2.528335   3.091831
+    14  H    2.772647   2.987887   3.742262   3.092186   2.549929
+    15  H    2.089008   2.589972   5.573027   4.804500   4.842638
+    16  H    2.123908   3.235404   4.890421   4.384796   4.755360
+    17  H    1.103929   1.989497   5.306903   5.506472   5.152039
+    18  H    2.436938   1.635683   5.898136   5.518829   4.684911
+    19  O    3.294408   2.606306   6.141671   5.555301   4.738061
+    20  O    3.527919   3.127687   6.595418   5.722124   5.291898
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.361113   0.000000
+    13  H    3.044233   3.477105   0.000000
+    14  H    2.473635   4.053258   1.755344   0.000000
+    15  H    3.799549   4.781966   2.412829   2.457688   0.000000
+    16  H    3.170393   3.427521   2.478281   3.063135   1.789493
+    17  H    2.894013   4.109431   4.141895   3.647529   2.995903
+    18  H    3.959311   5.919998   3.808124   2.438634   2.565486
+    19  O    4.503976   6.395979   3.852055   2.525746   2.894760
+    20  O    5.030162   6.562945   3.607854   2.856893   2.348885
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.401505   0.000000
+    18  H    3.870428   3.459770   0.000000
+    19  O    4.400811   4.359215   0.976569   0.000000
+    20  O    4.095788   4.622137   1.825101   1.303861   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2635703           0.8054337           0.6986359
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3442938818 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3319533504 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.002468    0.006117   -0.001256
+         Rot=    1.000000    0.000473    0.000076   -0.000436 Ang=   0.07 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957834351     A.U. after   17 cycles
+            NFock= 17  Conv=0.52D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15126967D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15177507D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000269704    0.000170409   -0.000278616
+      2        6          -0.000129408   -0.000543650    0.000306700
+      3        8          -0.000928917   -0.000433206    0.000813300
+      4        6          -0.000482505   -0.001600269   -0.000718767
+      5        6          -0.000395899    0.001211125    0.000094903
+      6        6           0.005570940   -0.001123734    0.003590079
+      7        8          -0.009363258   -0.003993235   -0.001620233
+      8        1          -0.000002226    0.000052295   -0.000005355
+      9        1           0.000005205   -0.000001751   -0.000005995
+     10        1          -0.000032710    0.000016470   -0.000007078
+     11        1           0.000088566   -0.000095680    0.000024306
+     12        1           0.001015589    0.000086039   -0.000413019
+     13        1          -0.000405610    0.000338437    0.000266123
+     14        1          -0.000564115   -0.000050773    0.000199325
+     15        1          -0.000271484   -0.000625319   -0.001148895
+     16        1          -0.000075347    0.000169757    0.000090690
+     17        1          -0.000695840    0.000480648   -0.000408252
+     18        1          -0.002881210   -0.015340128    0.002545697
+     19        8           0.007532509    0.020509182    0.000966369
+     20        8           0.001746017    0.000773383   -0.004291282
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.020509182 RMS     0.003902526
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0010428838
+ Magnitude of corrector gradient =     0.0085420569
+ Magnitude of analytic gradient =      0.0302288344
+ Magnitude of difference =             0.0257228593
+ Angle between gradients (degrees)=   50.9883
+ Pt  7 Step number   8 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  5.04D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.36D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  5.63D-06
+ Maximum DWI energy   std dev =  0.000404259 at pt    38
+ Maximum DWI gradient std dev =  1.302599756 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687066    1.408732    0.643318
+      2          6           0       -1.928921    0.142135    0.285065
+      3          8           0       -2.699017   -0.707739   -0.552411
+      4          6           0       -0.638959    0.447144   -0.456954
+      5          6           0        0.152474   -0.803062   -0.887952
+      6          6           0        0.654960   -1.599964    0.272510
+      7          8           0        1.611066   -1.296421    0.939125
+      8          1           0       -3.607027    1.170695    1.182429
+      9          1           0       -2.950615    1.960112   -0.261092
+     10          1           0       -2.083301    2.054001    1.283544
+     11          1           0       -1.683052   -0.391391    1.216258
+     12          1           0       -3.533359   -0.895255   -0.121003
+     13          1           0       -0.876037    1.010815   -1.361746
+     14          1           0       -0.010285    1.087719    0.162235
+     15          1           0        1.030736   -0.463611   -1.440723
+     16          1           0       -0.475803   -1.429117   -1.519994
+     17          1           0        0.100425   -2.513790    0.548619
+     18          1           0        2.205471    0.197859    0.709697
+     19          8           0        2.488280    1.108737    0.498865
+     20          8           0        2.681411    1.076672   -0.800391
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519012   0.000000
+     3  O    2.430918   1.420106   0.000000
+     4  C    2.515947   1.519086   2.363621   0.000000
+     5  C    3.911497   2.569353   2.872748   1.541149   0.000000
+     6  C    4.512082   3.116328   3.567313   2.529228   1.494729
+     7  O    5.087170   3.876693   4.598701   3.170437   2.389374
+     8  H    1.092534   2.163155   2.713424   3.467063   4.723986
+     9  H    1.091529   2.155734   2.695477   2.769691   4.202053
+    10  H    1.091235   2.162412   3.372988   2.774427   4.228108
+    11  H    2.139333   1.101009   2.064086   2.143107   2.822469
+    12  H    2.570750   1.953278   0.957811   3.208184   3.765910
+    13  H    2.731016   2.138962   2.632814   1.092053   2.138332
+    14  H    2.738548   2.142516   3.311143   1.090395   2.168971
+    15  H    4.655206   3.479201   3.841842   2.141298   1.091845
+    16  H    4.197975   2.799755   2.529681   2.162645   1.089108
+    17  H    4.813030   3.352856   3.508699   3.213253   2.234511
+    18  H    5.040590   4.156514   5.144612   3.084478   2.787314
+    19  O    5.186046   4.526775   5.595786   3.336303   3.321780
+    20  O    5.569121   4.827704   5.674030   3.396927   3.152235
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.204431   0.000000
+     8  H    5.164207   5.777055   0.000000
+     9  H    5.095002   5.731882   1.771386   0.000000
+    10  H    4.676721   4.999230   1.764142   1.773965   0.000000
+    11  H    2.795999   3.427404   2.478495   3.052678   2.478844
+    12  H    4.265381   5.267819   2.443873   2.917591   3.574008
+    13  H    3.439608   4.099150   3.735866   2.533077   3.089220
+    14  H    2.770983   2.986045   3.739550   3.096097   2.547240
+    15  H    2.089897   2.587283   5.573215   4.808027   4.843266
+    16  H    2.126237   3.227987   4.885354   4.381371   4.751420
+    17  H    1.104004   1.979020   5.265202   5.475426   5.116003
+    18  H    2.413997   1.624446   5.912277   5.534727   4.708304
+    19  O    3.278622   2.597715   6.133830   5.557333   4.733772
+    20  O    3.524485   3.130994   6.594306   5.726345   5.291544
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.337901   0.000000
+    13  H    3.043609   3.497700   0.000000
+    14  H    2.469186   4.052710   1.754410   0.000000
+    15  H    3.798606   4.770633   2.411628   2.461671   0.000000
+    16  H    3.165660   3.404531   2.477600   3.062852   1.791130
+    17  H    2.851510   4.033911   4.126235   3.623868   3.004363
+    18  H    3.965404   5.900774   3.800982   2.449723   2.538080
+    19  O    4.490551   6.376547   3.845788   2.521228   2.891144
+    20  O    5.026989   6.555412   3.602067   2.858671   2.346747
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.405767   0.000000
+    18  H    3.848091   3.436598   0.000000
+    19  O    4.393437   4.339013   0.976796   0.000000
+    20  O    4.094485   4.623065   1.810856   1.313923   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2675667           0.8068628           0.7001087
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.7049215892 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6925611519 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22652.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.002399   -0.005701    0.001202
+         Rot=    1.000000   -0.000387   -0.000097    0.000413 Ang=  -0.07 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957635390     A.U. after   17 cycles
+            NFock= 17  Conv=0.54D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15012601D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15066870D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22652.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000001317   -0.000012981   -0.000199971
+      2        6           0.000127244   -0.000594959    0.000756076
+      3        8           0.000482870   -0.000388524    0.000276017
+      4        6          -0.000120751   -0.002409054   -0.001024539
+      5        6           0.000198578    0.002087667   -0.000814185
+      6        6          -0.012053874   -0.004274141   -0.003242483
+      7        8           0.006917572    0.000036353    0.007105375
+      8        1          -0.000048740    0.000119514   -0.000002412
+      9        1           0.000059385    0.000011716   -0.000059676
+     10        1           0.000028546    0.000012995    0.000006675
+     11        1          -0.000090078   -0.000035136   -0.000017186
+     12        1          -0.000387652    0.000135910    0.000047750
+     13        1          -0.000549291    0.000304788    0.000146325
+     14        1          -0.000354167   -0.000032742    0.000272537
+     15        1          -0.000576859   -0.000659304   -0.001482928
+     16        1           0.000191746   -0.000120879   -0.000042866
+     17        1          -0.000521960   -0.000905422   -0.001454007
+     18        1          -0.003037404   -0.013764579    0.006519005
+     19        8           0.008199983    0.016835416   -0.009441551
+     20        8           0.001533534    0.003653361    0.002652045
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.016835416 RMS     0.004075476
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0012537070
+ Magnitude of corrector gradient =     0.0088303865
+ Magnitude of analytic gradient =      0.0315685042
+ Magnitude of difference =             0.0370879725
+ Angle between gradients (degrees)=  122.6725
+ Pt  7 Step number   9 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  6.32D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  4.17D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  6.85D-06
+ Maximum DWI energy   std dev =  0.000452356 at pt    -1
+ Maximum DWI gradient std dev =  1.303242843 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686822    1.409092    0.642820
+      2          6           0       -1.929106    0.142170    0.285271
+      3          8           0       -2.699391   -0.707071   -0.552940
+      4          6           0       -0.639571    0.446011   -0.458691
+      5          6           0        0.151822   -0.802448   -0.887061
+      6          6           0        0.653439   -1.602294    0.271758
+      7          8           0        1.618518   -1.290887    0.943813
+      8          1           0       -3.608894    1.172446    1.179190
+      9          1           0       -2.945881    1.962851   -0.261580
+     10          1           0       -2.083795    2.052183    1.285985
+     11          1           0       -1.685254   -0.391628    1.216675
+     12          1           0       -3.557565   -0.847439   -0.148027
+     13          1           0       -0.879700    1.007481   -1.364225
+     14          1           0       -0.009419    1.088071    0.158028
+     15          1           0        1.031974   -0.462784   -1.436904
+     16          1           0       -0.470747   -1.430877   -1.522761
+     17          1           0        0.129466   -2.541363    0.522028
+     18          1           0        2.194452    0.226599    0.739787
+     19          8           0        2.493783    1.121634    0.491445
+     20          8           0        2.682487    1.079036   -0.797964
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518903   0.000000
+     3  O    2.430667   1.420263   0.000000
+     4  C    2.516363   1.519440   2.362485   0.000000
+     5  C    3.910159   2.568449   2.872308   1.538978   0.000000
+     6  C    4.512590   3.116548   3.566934   2.530016   1.494736
+     7  O    5.090819   3.882392   4.607109   3.175342   2.396220
+     8  H    1.092663   2.163851   2.712942   3.468031   4.723621
+     9  H    1.091650   2.155866   2.697060   2.767440   4.199270
+    10  H    1.091269   2.161829   3.372548   2.776592   4.227178
+    11  H    2.138935   1.100871   2.063859   2.145214   2.823000
+    12  H    2.544713   1.954215   0.959229   3.206901   3.782559
+    13  H    2.730423   2.137956   2.628526   1.092201   2.137186
+    14  H    2.739810   2.143855   3.311187   1.090723   2.166166
+    15  H    4.653881   3.478484   3.842415   2.139363   1.091955
+    16  H    4.203112   2.805400   2.536001   2.164129   1.089326
+    17  H    4.853057   3.390445   3.538731   3.236916   2.238271
+    18  H    5.023398   4.149391   5.147095   3.084831   2.806762
+    19  O    5.190782   4.534733   5.603924   3.343223   3.329738
+    20  O    5.569046   4.828861   5.675811   3.398809   3.154708
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.216556   0.000000
+     8  H    5.166247   5.783533   0.000000
+     9  H    5.094096   5.733544   1.772045   0.000000
+    10  H    4.677211   5.000032   1.763879   1.773733   0.000000
+    11  H    2.797868   3.434826   2.479542   3.052539   2.477065
+    12  H    4.298672   5.308540   2.417453   2.878330   3.554743
+    13  H    3.440622   4.104952   3.734258   2.529361   3.092711
+    14  H    2.773153   2.987822   3.742474   3.092591   2.550457
+    15  H    2.088372   2.587973   5.572754   4.805041   4.842231
+    16  H    2.124495   3.235524   4.891401   4.385687   4.756331
+    17  H    1.104099   1.989690   5.310327   5.509968   5.155852
+    18  H    2.436929   1.635877   5.896315   5.517276   4.683427
+    19  O    3.294679   2.605952   6.141519   5.555596   4.738295
+    20  O    3.528579   3.127676   6.595403   5.722531   5.292192
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.361297   0.000000
+    13  H    3.044252   3.477187   0.000000
+    14  H    2.473594   4.053296   1.755318   0.000000
+    15  H    3.798667   4.782575   2.412769   2.456310   0.000000
+    16  H    3.171683   3.429101   2.477492   3.063164   1.789621
+    17  H    2.897775   4.112486   4.143749   3.650284   2.995401
+    18  H    3.957493   5.918401   3.806186   2.436725   2.562146
+    19  O    4.503362   6.395701   3.851874   2.525533   2.892369
+    20  O    5.029790   6.562924   3.607623   2.856635   2.347264
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.403039   0.000000
+    18  H    3.869062   3.460232   0.000000
+    19  O    4.400089   4.359871   0.975889   0.000000
+    20  O    4.094860   4.622508   1.824693   1.303840   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2634803           0.8054884           0.6986500
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3503099810 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3379703741 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.002358    0.005411   -0.001194
+         Rot=    1.000000    0.000313    0.000117   -0.000397 Ang=   0.06 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957792913     A.U. after   17 cycles
+            NFock= 17  Conv=0.54D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15123816D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15173936D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000263206    0.000154200   -0.000255088
+      2        6          -0.000119416   -0.000536067    0.000282091
+      3        8          -0.000943001   -0.000434755    0.000821767
+      4        6          -0.000487212   -0.001586391   -0.000762241
+      5        6          -0.000378331    0.001312437    0.000163361
+      6        6           0.005995542   -0.001322062    0.003464864
+      7        8          -0.009650284   -0.004038473   -0.001607385
+      8        1          -0.000003684    0.000064014   -0.000007764
+      9        1           0.000014789   -0.000006299   -0.000013341
+     10        1          -0.000026972    0.000017482   -0.000014195
+     11        1           0.000077178   -0.000098864    0.000038113
+     12        1           0.001031629    0.000083073   -0.000423209
+     13        1          -0.000433554    0.000357581    0.000288920
+     14        1          -0.000586287   -0.000055970    0.000209873
+     15        1          -0.000338712   -0.000674822   -0.001172254
+     16        1          -0.000094713    0.000129099    0.000127179
+     17        1          -0.000759878    0.000668016   -0.000382494
+     18        1          -0.003037022   -0.015883046    0.002704712
+     19        8           0.007726206    0.021085879    0.000846916
+     20        8           0.001750515    0.000764968   -0.004309827
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.021085879 RMS     0.004021858
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0010903680
+ Magnitude of corrector gradient =     0.0082409428
+ Magnitude of analytic gradient =      0.0311531771
+ Magnitude of difference =             0.0267534751
+ Angle between gradients (degrees)=   51.0642
+ Pt  7 Step number  10 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  4.73D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.15D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  5.26D-06
+ Maximum DWI energy   std dev =  0.000396506 at pt    37
+ Maximum DWI gradient std dev =  1.294290170 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687019    1.408787    0.643229
+      2          6           0       -1.928968    0.142111    0.285107
+      3          8           0       -2.699041   -0.707743   -0.552427
+      4          6           0       -0.638995    0.447181   -0.456922
+      5          6           0        0.152356   -0.803043   -0.887999
+      6          6           0        0.655274   -1.599641    0.272536
+      7          8           0        1.611390   -1.296146    0.939271
+      8          1           0       -3.607078    1.171069    1.182297
+      9          1           0       -2.950335    1.960061   -0.261321
+     10          1           0       -2.083125    2.054066    1.283327
+     11          1           0       -1.683262   -0.391404    1.216346
+     12          1           0       -3.533505   -0.895104   -0.121182
+     13          1           0       -0.876234    1.010974   -1.361594
+     14          1           0       -0.010303    1.087694    0.162326
+     15          1           0        1.029933   -0.464061   -1.441925
+     16          1           0       -0.476674   -1.429581   -1.518887
+     17          1           0        0.098670   -2.511583    0.550558
+     18          1           0        2.206478    0.198379    0.709672
+     19          8           0        2.488414    1.109210    0.498647
+     20          8           0        2.681400    1.076727   -0.800471
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.519001   0.000000
+     3  O    2.430933   1.420115   0.000000
+     4  C    2.515834   1.519112   2.363632   0.000000
+     5  C    3.911382   2.569320   2.872657   1.541145   0.000000
+     6  C    4.512093   3.116435   3.567559   2.529175   1.494770
+     7  O    5.087300   3.876938   4.599043   3.170612   2.389738
+     8  H    1.092525   2.163275   2.713619   3.467069   4.724044
+     9  H    1.091535   2.155624   2.695378   2.769360   4.201686
+    10  H    1.091237   2.162355   3.372971   2.774176   4.227897
+    11  H    2.139317   1.101007   2.064081   2.143254   2.822624
+    12  H    2.570755   1.953312   0.957813   3.208214   3.765907
+    13  H    2.730662   2.138877   2.632748   1.092052   2.138446
+    14  H    2.738463   2.142540   3.311159   1.090403   2.168992
+    15  H    4.655229   3.479249   3.841332   2.141475   1.091734
+    16  H    4.197227   2.798887   2.528639   2.162488   1.089150
+    17  H    4.810193   3.350205   3.506793   3.211456   2.234152
+    18  H    5.041410   4.157563   5.145684   3.085379   2.788336
+    19  O    5.186112   4.527045   5.596049   3.336478   3.322148
+    20  O    5.569062   4.827781   5.674064   3.396966   3.152342
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.204493   0.000000
+     8  H    5.164509   5.777423   0.000000
+     9  H    5.094791   5.731809   1.771398   0.000000
+    10  H    4.676549   4.999174   1.764178   1.773930   0.000000
+    11  H    2.796313   3.427836   2.478618   3.052599   2.478851
+    12  H    4.265825   5.268334   2.444083   2.917480   3.574053
+    13  H    3.439653   4.099397   3.735574   2.532441   3.088726
+    14  H    2.770724   2.986005   3.739530   3.095850   2.546981
+    15  H    2.090284   2.588543   5.573335   4.807569   4.843459
+    16  H    2.125893   3.228058   4.884589   4.380656   4.750672
+    17  H    1.103967   1.979067   5.262470   5.472767   5.112957
+    18  H    2.414580   1.624947   5.913285   5.535257   4.708859
+    19  O    3.278628   2.597895   6.134022   5.557112   4.733650
+    20  O    3.524127   3.130839   6.594333   5.726028   5.291323
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.337968   0.000000
+    13  H    3.043637   3.497548   0.000000
+    14  H    2.469307   4.052754   1.754438   0.000000
+    15  H    3.799093   4.770233   2.411567   2.462449   0.000000
+    16  H    3.164675   3.403449   2.478044   3.062785   1.791093
+    17  H    2.848458   4.031989   4.124945   3.621794   3.004926
+    18  H    3.966691   5.901985   3.801785   2.450426   2.540169
+    19  O    4.491081   6.376909   3.845907   2.521341   2.892779
+    20  O    5.027248   6.555501   3.602213   2.858734   2.347943
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.405067   0.000000
+    18  H    3.849160   3.436869   0.000000
+    19  O    4.394047   4.338630   0.976541   0.000000
+    20  O    4.095257   4.622958   1.810408   1.313776   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2676539           0.8068094           0.7000845
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.7018000251 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6894385200 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22651.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.002316   -0.005114    0.001187
+         Rot=    1.000000   -0.000240   -0.000131    0.000382 Ang=  -0.05 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957630087     A.U. after   17 cycles
+            NFock= 17  Conv=0.57D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15014016D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15068461D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22651.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000010569    0.000005027   -0.000219893
+      2        6           0.000117382   -0.000596369    0.000766402
+      3        8           0.000479472   -0.000385838    0.000277075
+      4        6          -0.000112116   -0.002415841   -0.000975434
+      5        6           0.000201912    0.001952115   -0.000859475
+      6        6          -0.012206498   -0.004001561   -0.002946053
+      7        8           0.006903424   -0.000038562    0.006924605
+      8        1          -0.000046995    0.000110079   -0.000000217
+      9        1           0.000050942    0.000015619   -0.000053764
+     10        1           0.000022591    0.000012340    0.000012385
+     11        1          -0.000080152   -0.000034163   -0.000024426
+     12        1          -0.000382894    0.000138270    0.000049736
+     13        1          -0.000535087    0.000290523    0.000136248
+     14        1          -0.000355172   -0.000032250    0.000265761
+     15        1          -0.000521631   -0.000626597   -0.001490066
+     16        1           0.000215921   -0.000089147   -0.000071539
+     17        1          -0.000440566   -0.001012982   -0.001509240
+     18        1          -0.003103427   -0.013944832    0.006589822
+     19        8           0.008222127    0.016976072   -0.009362551
+     20        8           0.001560197    0.003678096    0.002490622
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.016976072 RMS     0.004087596
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0012754240
+ Magnitude of corrector gradient =     0.0088133515
+ Magnitude of analytic gradient =      0.0316623845
+ Magnitude of difference =             0.0371063253
+ Angle between gradients (degrees)=  122.1148
+ Pt  7 Step number  11 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  5.03D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.31D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  6.95D-06
+ Maximum DWI energy   std dev =  0.000434755 at pt    48
+ Maximum DWI gradient std dev =  1.294979386 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686855    1.409044    0.642892
+      2          6           0       -1.929072    0.142196    0.285228
+      3          8           0       -2.699371   -0.707073   -0.552929
+      4          6           0       -0.639535    0.446022   -0.458689
+      5          6           0        0.151959   -0.802450   -0.887008
+      6          6           0        0.653365   -1.602453    0.271800
+      7          8           0        1.618085   -1.291252    0.943583
+      8          1           0       -3.608895    1.172146    1.179225
+      9          1           0       -2.946014    1.962956   -0.261381
+     10          1           0       -2.083956    2.052071    1.286233
+     11          1           0       -1.685047   -0.391641    1.216566
+     12          1           0       -3.558008   -0.846426   -0.148500
+     13          1           0       -0.879444    1.007289   -1.364417
+     14          1           0       -0.009346    1.088201    0.157871
+     15          1           0        1.032800   -0.462059   -1.435547
+     16          1           0       -0.469956   -1.430389   -1.523772
+     17          1           0        0.132043   -2.543829    0.519900
+     18          1           0        2.192406    0.226579    0.740038
+     19          8           0        2.493461    1.120770    0.491793
+     20          8           0        2.682450    1.078938   -0.797970
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518902   0.000000
+     3  O    2.430658   1.420255   0.000000
+     4  C    2.516428   1.519417   2.362506   0.000000
+     5  C    3.910264   2.568498   2.872419   1.539027   0.000000
+     6  C    4.512638   3.116563   3.566892   2.530110   1.494741
+     7  O    5.090631   3.882078   4.606651   3.175112   2.395729
+     8  H    1.092671   2.163754   2.712758   3.468013   4.723597
+     9  H    1.091646   2.155950   2.697200   2.767646   4.199561
+    10  H    1.091265   2.161857   3.372555   2.776778   4.227362
+    11  H    2.138969   1.100873   2.063846   2.145053   2.822832
+    12  H    2.544082   1.954207   0.959291   3.206887   3.783013
+    13  H    2.730829   2.138090   2.628628   1.092209   2.137023
+    14  H    2.739935   2.143944   3.311266   1.090724   2.166184
+    15  H    4.653684   3.478344   3.842935   2.139058   1.092082
+    16  H    4.203743   2.806158   2.536930   2.164273   1.089291
+    17  H    4.856596   3.393817   3.541403   3.239163   2.238792
+    18  H    5.021439   4.147355   5.145187   3.083017   2.805281
+    19  O    5.190531   4.534212   5.603388   3.342808   3.329039
+    20  O    5.569065   4.828761   5.675727   3.398717   3.154510
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.216068   0.000000
+     8  H    5.166109   5.783180   0.000000
+     9  H    5.094306   5.733481   1.772043   0.000000
+    10  H    4.677344   5.000033   1.763847   1.773752   0.000000
+    11  H    2.797646   3.434312   2.479519   3.052620   2.477037
+    12  H    4.299290   5.308715   2.416625   2.877482   3.554233
+    13  H    3.440562   4.104608   3.734593   2.529959   3.093277
+    14  H    2.773407   2.987921   3.742588   3.092731   2.550736
+    15  H    2.087943   2.586577   5.572521   4.805239   4.841808
+    16  H    2.124979   3.235292   4.892067   4.386261   4.756959
+    17  H    1.104318   1.989164   5.313925   5.513252   5.159479
+    18  H    2.435827   1.635569   5.894241   5.515542   4.681669
+    19  O    3.293979   2.605427   6.141168   5.555577   4.738271
+    20  O    3.528661   3.127888   6.595377   5.722675   5.292402
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.361825   0.000000
+    13  H    3.044252   3.476984   0.000000
+    14  H    2.473609   4.053350   1.755271   0.000000
+    15  H    3.798073   4.783278   2.412617   2.455271   0.000000
+    16  H    3.172522   3.430518   2.476964   3.063231   1.789895
+    17  H    2.901564   4.116359   4.145382   3.652766   2.994813
+    18  H    3.955239   5.916764   3.804537   2.434959   2.559703
+    19  O    4.502512   6.395320   3.851608   2.525195   2.890245
+    20  O    5.029511   6.562938   3.607365   2.856480   2.345745
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.403902   0.000000
+    18  H    3.867629   3.459583   0.000000
+    19  O    4.399177   4.359630   0.975622   0.000000
+    20  O    4.094042   4.622315   1.825412   1.304207   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2635477           0.8055701           0.6987120
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3653695375 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3530308381 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.002217    0.004789   -0.001192
+         Rot=    1.000000    0.000154    0.000152   -0.000356 Ang=   0.05 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957766102     A.U. after   17 cycles
+            NFock= 17  Conv=0.54D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15124955D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15174604D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22633.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000253558    0.000139791   -0.000239162
+      2        6          -0.000101949   -0.000527168    0.000272869
+      3        8          -0.000998378   -0.000433635    0.000842841
+      4        6          -0.000484345   -0.001603125   -0.000839371
+      5        6          -0.000396152    0.001516931    0.000254378
+      6        6           0.005672649   -0.001956507    0.002861951
+      7        8          -0.009162643   -0.003737177   -0.001088603
+      8        1          -0.000005505    0.000072246   -0.000007646
+      9        1           0.000021002   -0.000009445   -0.000018394
+     10        1          -0.000022415    0.000018987   -0.000017556
+     11        1           0.000063768   -0.000097979    0.000048164
+     12        1           0.001090560    0.000081581   -0.000449340
+     13        1          -0.000457903    0.000376802    0.000307377
+     14        1          -0.000600523   -0.000060431    0.000223386
+     15        1          -0.000408827   -0.000736669   -0.001186242
+     16        1          -0.000091672    0.000094965    0.000156157
+     17        1          -0.000870626    0.000849556   -0.000371317
+     18        1          -0.003064354   -0.016133103    0.002635459
+     19        8           0.007898793    0.021461838    0.000491991
+     20        8           0.001664962    0.000682542   -0.003876939
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.021461838 RMS     0.004033024
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0011270014
+ Magnitude of corrector gradient =     0.0077371717
+ Magnitude of analytic gradient =      0.0312396707
+ Magnitude of difference =             0.0270406143
+ Angle between gradients (degrees)=   50.9444
+ Pt  7 Step number  12 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  4.20D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  2.80D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  4.83D-06
+ Maximum DWI energy   std dev =  0.000389022 at pt    35
+ Maximum DWI gradient std dev =  1.281051410 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687002    1.408826    0.643180
+      2          6           0       -1.928987    0.142119    0.285128
+      3          8           0       -2.699063   -0.707716   -0.552450
+      4          6           0       -0.639013    0.447170   -0.456959
+      5          6           0        0.152214   -0.803072   -0.887996
+      6          6           0        0.655355   -1.599632    0.272553
+      7          8           0        1.611868   -1.295679    0.939454
+      8          1           0       -3.607072    1.171266    1.182288
+      9          1           0       -2.950271    1.959987   -0.261455
+     10          1           0       -2.083006    2.054153    1.283141
+     11          1           0       -1.683377   -0.391373    1.216386
+     12          1           0       -3.533098   -0.896002   -0.120748
+     13          1           0       -0.876291    1.011014   -1.361597
+     14          1           0       -0.010213    1.087606    0.162299
+     15          1           0        1.029401   -0.464516   -1.442545
+     16          1           0       -0.477264   -1.429868   -1.518248
+     17          1           0        0.096583   -2.509486    0.552902
+     18          1           0        2.207749    0.199457    0.708524
+     19          8           0        2.488695    1.109927    0.498298
+     20          8           0        2.681449    1.076822   -0.800384
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518991   0.000000
+     3  O    2.430931   1.420132   0.000000
+     4  C    2.515820   1.519138   2.363618   0.000000
+     5  C    3.911283   2.569241   2.872536   1.541083   0.000000
+     6  C    4.512154   3.116517   3.567670   2.529224   1.494836
+     7  O    5.087475   3.877249   4.599522   3.170797   2.390152
+     8  H    1.092520   2.163333   2.713738   3.467106   4.724015
+     9  H    1.091537   2.155555   2.695260   2.769251   4.201483
+    10  H    1.091242   2.162319   3.372957   2.774069   4.227739
+    11  H    2.139286   1.100991   2.064092   2.143347   2.822643
+    12  H    2.571321   1.953357   0.957827   3.208251   3.765478
+    13  H    2.730578   2.138889   2.632727   1.092058   2.138464
+    14  H    2.738545   2.142598   3.311188   1.090426   2.168909
+    15  H    4.655245   3.479212   3.840945   2.141531   1.091605
+    16  H    4.196772   2.798358   2.527975   2.162352   1.089189
+    17  H    4.807251   3.347484   3.504828   3.209788   2.234084
+    18  H    5.042364   4.158742   5.146827   3.086060   2.789116
+    19  O    5.186344   4.527472   5.596493   3.336813   3.322728
+    20  O    5.569055   4.827849   5.674149   3.397039   3.152572
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.205015   0.000000
+     8  H    5.164667   5.777726   0.000000
+     9  H    5.094761   5.731898   1.771401   0.000000
+    10  H    4.676543   4.999159   1.764210   1.773920   0.000000
+    11  H    2.796494   3.428279   2.478630   3.052528   2.478861
+    12  H    4.265316   5.268248   2.444785   2.918246   3.574504
+    13  H    3.439747   4.099585   3.735531   2.532243   3.088517
+    14  H    2.770630   2.985827   3.739622   3.095894   2.546953
+    15  H    2.090445   2.589212   5.573366   4.807387   4.843566
+    16  H    2.125703   3.228433   4.884106   4.380229   4.750220
+    17  H    1.103927   1.979606   5.259385   5.470164   5.109859
+    18  H    2.415931   1.625987   5.914475   5.535838   4.709635
+    19  O    3.279300   2.598150   6.134327   5.557173   4.733708
+    20  O    3.524154   3.130463   6.594347   5.725967   5.291152
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.337530   0.000000
+    13  H    3.043694   3.497862   0.000000
+    14  H    2.469404   4.052843   1.754484   0.000000
+    15  H    3.799267   4.769667   2.411515   2.462804   0.000000
+    16  H    3.164080   3.402372   2.478239   3.062687   1.790998
+    17  H    2.845149   4.028861   4.123798   3.619814   3.005639
+    18  H    3.968358   5.902969   3.802017   2.450822   2.540958
+    19  O    4.491740   6.377221   3.846053   2.521494   2.894008
+    20  O    5.027391   6.555496   3.602334   2.858657   2.348906
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.405107   0.000000
+    18  H    3.850002   3.437967   0.000000
+    19  O    4.394762   4.338817   0.975747   0.000000
+    20  O    4.095888   4.623259   1.808581   1.313326   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2676636           0.8067373           0.7000274
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.6943950709 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6820323486 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22650.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.002106   -0.004463    0.001197
+         Rot=    1.000000   -0.000067   -0.000170    0.000328 Ang=  -0.04 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957612261     A.U. after   17 cycles
+            NFock= 17  Conv=0.55D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15010851D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15065503D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22650.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000018206    0.000018737   -0.000229053
+      2        6           0.000107031   -0.000594491    0.000760991
+      3        8           0.000470092   -0.000392907    0.000289818
+      4        6          -0.000102579   -0.002405921   -0.000906397
+      5        6           0.000239066    0.001739895   -0.000910750
+      6        6          -0.011804490   -0.003418189   -0.002243146
+      7        8           0.006291488   -0.000367168    0.006327095
+      8        1          -0.000044830    0.000105129   -0.000000594
+      9        1           0.000046194    0.000018458   -0.000050530
+     10        1           0.000017689    0.000011633    0.000014636
+     11        1          -0.000069508   -0.000036828   -0.000026551
+     12        1          -0.000372433    0.000148145    0.000043206
+     13        1          -0.000527823    0.000276692    0.000134142
+     14        1          -0.000371135   -0.000032993    0.000257708
+     15        1          -0.000463610   -0.000587462   -0.001522042
+     16        1           0.000229465   -0.000063085   -0.000091644
+     17        1          -0.000319092   -0.001105785   -0.001572374
+     18        1          -0.003319613   -0.014515428    0.006949158
+     19        8           0.008299265    0.017387862   -0.009165717
+     20        8           0.001676616    0.003813708    0.001942044
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.017387862 RMS     0.004085888
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0013135937
+ Magnitude of corrector gradient =     0.0086783961
+ Magnitude of analytic gradient =      0.0316491497
+ Magnitude of difference =             0.0367157251
+ Angle between gradients (degrees)=  119.5671
+ Pt  7 Step number  13 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  5.31D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.51D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  6.74D-06
+ Maximum DWI energy   std dev =  0.000409204 at pt    41
+ Maximum DWI gradient std dev =  1.278470356 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686872    1.409007    0.642943
+      2          6           0       -1.929056    0.142213    0.285188
+      3          8           0       -2.699344   -0.707101   -0.552909
+      4          6           0       -0.639490    0.446113   -0.458591
+      5          6           0        0.152113   -0.802430   -0.886992
+      6          6           0        0.653514   -1.602353    0.271863
+      7          8           0        1.617402   -1.291852    0.943231
+      8          1           0       -3.608934    1.171942    1.179178
+      9          1           0       -2.946016    1.963084   -0.261231
+     10          1           0       -2.084091    2.051941    1.286474
+     11          1           0       -1.684862   -0.391679    1.216464
+     12          1           0       -3.558820   -0.844672   -0.149387
+     13          1           0       -0.879155    1.007222   -1.364484
+     14          1           0       -0.009319    1.088410    0.157850
+     15          1           0        1.033491   -0.461214   -1.434456
+     16          1           0       -0.469426   -1.429931   -1.524488
+     17          1           0        0.134909   -2.546174    0.517590
+     18          1           0        2.189710    0.226048    0.740953
+     19          8           0        2.492845    1.119285    0.492386
+     20          8           0        2.682327    1.078755   -0.798123
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518895   0.000000
+     3  O    2.430665   1.420241   0.000000
+     4  C    2.516409   1.519389   2.362583   0.000000
+     5  C    3.910369   2.568584   2.872543   1.539163   0.000000
+     6  C    4.512668   3.116626   3.566985   2.530146   1.494732
+     7  O    5.090343   3.881614   4.605938   3.174774   2.395062
+     8  H    1.092678   2.163689   2.712616   3.467954   4.723629
+     9  H    1.091644   2.156003   2.697371   2.767708   4.199767
+    10  H    1.091256   2.161867   3.372562   2.776834   4.227528
+    11  H    2.139023   1.100884   2.063819   2.144879   2.822715
+    12  H    2.543059   1.954207   0.959403   3.206902   3.783763
+    13  H    2.731124   2.138213   2.628810   1.092211   2.136902
+    14  H    2.739961   2.144037   3.311385   1.090716   2.166341
+    15  H    4.653430   3.478216   3.843389   2.138790   1.092233
+    16  H    4.204092   2.806615   2.537515   2.164394   1.089251
+    17  H    4.860208   3.397262   3.544171   3.241359   2.239150
+    18  H    5.018969   4.144754   5.142732   3.080861   2.803529
+    19  O    5.189998   4.533300   5.602424   3.342012   3.327867
+    20  O    5.569025   4.828616   5.675543   3.398527   3.154162
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.215001   0.000000
+     8  H    5.166081   5.782779   0.000000
+     9  H    5.094423   5.733247   1.772045   0.000000
+    10  H    4.677369   4.999982   1.763818   1.773753   0.000000
+    11  H    2.797500   3.433645   2.479587   3.052704   2.477007
+    12  H    4.300614   5.309148   2.415436   2.876027   3.553433
+    13  H    3.440434   4.104155   3.734842   2.530366   3.093685
+    14  H    2.773545   2.988092   3.742635   3.092713   2.550855
+    15  H    2.087607   2.585403   5.572287   4.805221   4.841355
+    16  H    2.125465   3.234742   4.892450   4.386555   4.757319
+    17  H    1.104596   1.988034   5.317748   5.516527   5.163120
+    18  H    2.433720   1.634770   5.891606   5.513378   4.679407
+    19  O    3.292276   2.604466   6.140534   5.555280   4.738013
+    20  O    3.528355   3.128283   6.595329   5.722633   5.292578
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.362725   0.000000
+    13  H    3.044237   3.476576   0.000000
+    14  H    2.473615   4.053413   1.755195   0.000000
+    15  H    3.797585   4.784115   2.412346   2.454430   0.000000
+    16  H    3.173023   3.431878   2.476528   3.063332   1.790329
+    17  H    2.905485   4.121116   4.146945   3.655191   2.994160
+    18  H    3.952215   5.914790   3.802766   2.432983   2.557650
+    19  O    4.501170   6.394657   3.851092   2.524617   2.887977
+    20  O    5.029222   6.562952   3.606942   2.856385   2.344159
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.404435   0.000000
+    18  H    3.865940   3.457935   0.000000
+    19  O    4.397878   4.358450   0.975474   0.000000
+    20  O    4.093245   4.621748   1.827166   1.304975   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2638146           0.8057038           0.6988391
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.3939798523 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.3816419107 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22634.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.001889    0.004006   -0.001187
+         Rot=    1.000000   -0.000046    0.000198   -0.000280 Ang=  -0.04 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957735367     A.U. after   16 cycles
+            NFock= 16  Conv=0.99D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15127835D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15176870D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22634.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000239752    0.000126987   -0.000228369
+      2        6          -0.000076748   -0.000517083    0.000279273
+      3        8          -0.001099551   -0.000428744    0.000879435
+      4        6          -0.000473580   -0.001654240   -0.000948490
+      5        6          -0.000431825    0.001826146    0.000362215
+      6        6           0.004670015   -0.002969027    0.001820005
+      7        8          -0.007982162   -0.003155734   -0.000091089
+      8        1          -0.000007885    0.000078611   -0.000005368
+      9        1           0.000025117   -0.000011579   -0.000022532
+     10        1          -0.000018030    0.000021057   -0.000018245
+     11        1           0.000045085   -0.000093331    0.000055980
+     12        1           0.001197195    0.000080727   -0.000494836
+     13        1          -0.000485847    0.000399181    0.000323062
+     14        1          -0.000608101   -0.000067241    0.000240344
+     15        1          -0.000494177   -0.000816438   -0.001197894
+     16        1          -0.000069981    0.000056988    0.000178274
+     17        1          -0.001019578    0.001032854   -0.000378337
+     18        1          -0.003031675   -0.016323071    0.002382471
+     19        8           0.008139841    0.021902069   -0.000161769
+     20        8           0.001482136    0.000511866   -0.002974128
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.021902069 RMS     0.004007590
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0011800765
+ Magnitude of corrector gradient =     0.0071277218
+ Magnitude of analytic gradient =      0.0310426574
+ Magnitude of difference =             0.0273778425
+ Angle between gradients (degrees)=   53.2290
+ Pt  7 Step number  14 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  3.50D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  2.34D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  4.31D-06
+ Maximum DWI energy   std dev =  0.000379631 at pt    33
+ Maximum DWI gradient std dev =  1.261229785 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687000    1.408853    0.643148
+      2          6           0       -1.928990    0.142141    0.285140
+      3          8           0       -2.699093   -0.707669   -0.552485
+      4          6           0       -0.639035    0.447112   -0.457075
+      5          6           0        0.152061   -0.803115   -0.887962
+      6          6           0        0.655300   -1.599823    0.272565
+      7          8           0        1.612562   -1.295011    0.939708
+      8          1           0       -3.607030    1.171375    1.182356
+      9          1           0       -2.950327    1.959891   -0.261544
+     10          1           0       -2.082906    2.054253    1.282959
+     11          1           0       -1.683454   -0.391323    1.216402
+     12          1           0       -3.532334   -0.897601   -0.119922
+     13          1           0       -0.876359    1.010929   -1.361735
+     14          1           0       -0.010057    1.087490    0.162124
+     15          1           0        1.029017   -0.465005   -1.442847
+     16          1           0       -0.477611   -1.430098   -1.517906
+     17          1           0        0.094393   -2.507540    0.555409
+     18          1           0        2.209487    0.201250    0.706609
+     19          8           0        2.489162    1.111054    0.497764
+     20          8           0        2.681547    1.076964   -0.800165
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518983   0.000000
+     3  O    2.430916   1.420159   0.000000
+     4  C    2.515870   1.519170   2.363570   0.000000
+     5  C    3.911186   2.569135   2.872409   1.540962   0.000000
+     6  C    4.512254   3.116594   3.567716   2.529352   1.494930
+     7  O    5.087737   3.877688   4.600216   3.171070   2.390691
+     8  H    1.092517   2.163361   2.713821   3.467172   4.723938
+     9  H    1.091536   2.155506   2.695114   2.769261   4.201359
+    10  H    1.091251   2.162291   3.372944   2.774055   4.227591
+    11  H    2.139242   1.100963   2.064112   2.143434   2.822594
+    12  H    2.572275   1.953421   0.957850   3.208288   3.764782
+    13  H    2.730627   2.138931   2.632645   1.092073   2.138426
+    14  H    2.738738   2.142690   3.311219   1.090460   2.168721
+    15  H    4.655267   3.479135   3.840630   2.141519   1.091452
+    16  H    4.196571   2.798110   2.527633   2.162254   1.089231
+    17  H    4.804371   3.344837   3.502931   3.208272   2.234213
+    18  H    5.043602   4.160303   5.148360   3.086857   2.790055
+    19  O    5.186760   4.528142   5.597210   3.337386   3.323600
+    20  O    5.569076   4.827923   5.674288   3.397159   3.152888
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.205961   0.000000
+     8  H    5.164757   5.778069   0.000000
+     9  H    5.094839   5.732134   1.771401   0.000000
+    10  H    4.676638   4.999188   1.764241   1.773925   0.000000
+    11  H    2.796619   3.428839   2.478573   3.052457   2.478877
+    12  H    4.264205   5.267895   2.445847   2.919598   3.575243
+    13  H    3.439905   4.099846   3.735599   2.532251   3.088477
+    14  H    2.770658   2.985606   3.739802   3.096089   2.547078
+    15  H    2.090482   2.589596   5.573362   4.807367   4.843629
+    16  H    2.125578   3.229078   4.883886   4.380046   4.750002
+    17  H    1.103887   1.980593   5.256234   5.467693   5.106849
+    18  H    2.418213   1.627714   5.916024   5.536589   4.710673
+    19  O    3.280642   2.598632   6.134806   5.557437   4.733916
+    20  O    3.524431   3.129881   6.594354   5.726053   5.290984
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.336758   0.000000
+    13  H    3.043765   3.498398   0.000000
+    14  H    2.469544   4.052971   1.754562   0.000000
+    15  H    3.799281   4.768983   2.411518   2.462894   0.000000
+    16  H    3.163788   3.401360   2.478307   3.062574   1.790801
+    17  H    2.841835   4.025062   4.122793   3.617985   3.006410
+    18  H    3.970645   5.904163   3.802115   2.451176   2.541175
+    19  O    4.492694   6.377668   3.846361   2.521766   2.895161
+    20  O    5.027489   6.555453   3.602558   2.858469   2.349801
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.405557   0.000000
+    18  H    3.851008   3.440062   0.000000
+    19  O    4.395693   4.339638   0.974462   0.000000
+    20  O    4.096437   4.623809   1.805570   1.312553   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2675656           0.8066312           0.6999266
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.6798421927 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6674783420 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.001679   -0.003583    0.001178
+         Rot=    1.000000    0.000154   -0.000222    0.000233 Ang=   0.04 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957581361     A.U. after   17 cycles
+            NFock= 17  Conv=0.49D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15005215D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15060172D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000027426    0.000031290   -0.000231911
+      2        6           0.000094126   -0.000592052    0.000741555
+      3        8           0.000453934   -0.000408008    0.000312068
+      4        6          -0.000097329   -0.002378328   -0.000821889
+      5        6           0.000292285    0.001454608   -0.000962546
+      6        6          -0.010874652   -0.002576701   -0.001189796
+      7        8           0.005129878   -0.000906767    0.005351588
+      8        1          -0.000042054    0.000102199   -0.000002846
+      9        1           0.000043276    0.000020727   -0.000048272
+     10        1           0.000012578    0.000010881    0.000014643
+     11        1          -0.000055409   -0.000042450   -0.000025002
+     12        1          -0.000355556    0.000164069    0.000030474
+     13        1          -0.000520016    0.000262261    0.000138363
+     14        1          -0.000398412   -0.000032960    0.000248499
+     15        1          -0.000394191   -0.000537631   -0.001566255
+     16        1           0.000230727   -0.000035482   -0.000103329
+     17        1          -0.000166047   -0.001180774   -0.001631555
+     18        1          -0.003676837   -0.015452331    0.007549637
+     19        8           0.008420366    0.018059604   -0.008808883
+     20        8           0.001875907    0.004037846    0.001005456
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.018059604 RMS     0.004093839
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0013744004
+ Magnitude of corrector gradient =     0.0084687187
+ Magnitude of analytic gradient =      0.0317107401
+ Magnitude of difference =             0.0360279271
+ Angle between gradients (degrees)=  114.2646
+ Pt  7 Step number  15 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  5.58D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.68D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  5.47D-06
+ Maximum DWI energy   std dev =  0.000386201 at pt    35
+ Maximum DWI gradient std dev =  1.259276012 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686881    1.408979    0.642980
+      2          6           0       -1.929052    0.142222    0.285158
+      3          8           0       -2.699311   -0.707146   -0.552880
+      4          6           0       -0.639434    0.446250   -0.458415
+      5          6           0        0.152253   -0.802408   -0.887023
+      6          6           0        0.653767   -1.602065    0.271934
+      7          8           0        1.616594   -1.292561    0.942812
+      8          1           0       -3.608969    1.171808    1.179129
+      9          1           0       -2.945997    1.963171   -0.261129
+     10          1           0       -2.084190    2.051845    1.286645
+     11          1           0       -1.684712   -0.391717    1.216394
+     12          1           0       -3.559432   -0.843328   -0.150051
+     13          1           0       -0.878833    1.007360   -1.364363
+     14          1           0       -0.009375    1.088584    0.158071
+     15          1           0        1.033921   -0.460499   -1.433879
+     16          1           0       -0.469244   -1.429572   -1.524819
+     17          1           0        0.137026   -2.547701    0.515735
+     18          1           0        2.187375    0.225011    0.742065
+     19          8           0        2.492091    1.117512    0.493108
+     20          8           0        2.682163    1.078529   -0.798370
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518886   0.000000
+     3  O    2.430683   1.420222   0.000000
+     4  C    2.516338   1.519358   2.362698   0.000000
+     5  C    3.910476   2.568689   2.872655   1.539357   0.000000
+     6  C    4.512648   3.116676   3.567119   2.530093   1.494707
+     7  O    5.090001   3.881072   4.605089   3.174361   2.394335
+     8  H    1.092680   2.163643   2.712526   3.467869   4.723695
+     9  H    1.091643   2.156030   2.697512   2.767707   4.199919
+    10  H    1.091246   2.161876   3.372575   2.776776   4.227678
+    11  H    2.139077   1.100906   2.063792   2.144709   2.822670
+    12  H    2.542269   1.954189   0.959491   3.206944   3.784363
+    13  H    2.731257   2.138304   2.629102   1.092199   2.136879
+    14  H    2.739859   2.144042   3.311473   1.090698   2.166609
+    15  H    4.653242   3.478156   3.843699   2.138654   1.092379
+    16  H    4.204122   2.806705   2.537669   2.164461   1.089210
+    17  H    4.862711   3.399636   3.546039   3.242776   2.239198
+    18  H    5.016969   4.142535   5.140575   3.079115   2.802006
+    19  O    5.189331   4.532211   5.601261   3.341023   3.326514
+    20  O    5.568961   4.828459   5.675312   3.398287   3.153764
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.213633   0.000000
+     8  H    5.166071   5.782341   0.000000
+     9  H    5.094445   5.732932   1.772041   0.000000
+    10  H    4.677297   4.999908   1.763796   1.773747   0.000000
+    11  H    2.797397   3.432927   2.479670   3.052771   2.476997
+    12  H    4.301721   5.309181   2.414528   2.874905   3.552811
+    13  H    3.440266   4.103639   3.734975   2.530587   3.093813
+    14  H    2.773502   2.988219   3.742534   3.092633   2.550766
+    15  H    2.087460   2.584666   5.572133   4.805130   4.841047
+    16  H    2.125848   3.233991   4.892482   4.386562   4.757378
+    17  H    1.104847   1.986679   5.320462   5.518742   5.165649
+    18  H    2.431292   1.633743   5.889402   5.511725   4.677623
+    19  O    3.290053   2.603302   6.139747   5.554891   4.737618
+    20  O    3.527821   3.128773   6.595266   5.722535   5.292707
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.363409   0.000000
+    13  H    3.044202   3.476379   0.000000
+    14  H    2.473478   4.053409   1.755095   0.000000
+    15  H    3.797321   4.784732   2.412067   2.454064   0.000000
+    16  H    3.173131   3.432627   2.476317   3.063448   1.790776
+    17  H    2.908250   4.124556   4.147914   3.656765   2.993631
+    18  H    3.949481   5.912953   3.801413   2.431568   2.556387
+    19  O    4.499621   6.393706   3.850384   2.523969   2.886114
+    20  O    5.028965   6.562877   3.606398   2.856442   2.342900
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.404503   0.000000
+    18  H    3.864458   3.455877   0.000000
+    19  O    4.396495   4.356676   0.975391   0.000000
+    20  O    4.092636   4.621053   1.829275   1.305972   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2642091           0.8058613           0.6990017
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.4297282026 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.4173905830 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.001396    0.003063   -0.001138
+         Rot=    1.000000   -0.000271    0.000248   -0.000174 Ang=  -0.05 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957703055     A.U. after   16 cycles
+            NFock= 16  Conv=0.94D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15130291D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15178819D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000222807    0.000115637   -0.000222958
+      2        6          -0.000050748   -0.000512749    0.000301313
+      3        8          -0.001178576   -0.000420018    0.000905575
+      4        6          -0.000457529   -0.001724226   -0.001053308
+      5        6          -0.000467443    0.002166520    0.000445255
+      6        6           0.003237411   -0.004062685    0.000597448
+      7        8          -0.006409602   -0.002471614    0.001132215
+      8        1          -0.000011122    0.000083349   -0.000002041
+      9        1           0.000027731   -0.000012442   -0.000025910
+     10        1          -0.000013523    0.000022877   -0.000017080
+     11        1           0.000025052   -0.000086586    0.000058189
+     12        1           0.001280786    0.000079024   -0.000531689
+     13        1          -0.000511694    0.000418806    0.000326431
+     14        1          -0.000600343   -0.000074264    0.000253295
+     15        1          -0.000578549   -0.000892213   -0.001199108
+     16        1          -0.000041269    0.000020652    0.000188435
+     17        1          -0.001157430    0.001160344   -0.000390136
+     18        1          -0.002979019   -0.016459781    0.002066311
+     19        8           0.008405905    0.022328117   -0.000993311
+     20        8           0.001257155    0.000321253   -0.001838926
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.022328117 RMS     0.003991172
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0012453660
+ Magnitude of corrector gradient =     0.0068149931
+ Magnitude of analytic gradient =      0.0309154866
+ Magnitude of difference =             0.0282532740
+ Angle between gradients (degrees)=   61.0504
+ Pt  7 Step number  16 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  3.71D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  2.45D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  3.87D-06
+ Maximum DWI energy   std dev =  0.000371670 at pt    31
+ Maximum DWI gradient std dev =  1.244083102 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687003    1.408872    0.643129
+      2          6           0       -1.928987    0.142162    0.285149
+      3          8           0       -2.699122   -0.707618   -0.552520
+      4          6           0       -0.639066    0.447031   -0.457231
+      5          6           0        0.151934   -0.803153   -0.887912
+      6          6           0        0.655170   -1.600115    0.272560
+      7          8           0        1.613248   -1.294369    0.939975
+      8          1           0       -3.606994    1.171438    1.182419
+      9          1           0       -2.950385    1.959827   -0.261597
+     10          1           0       -2.082836    2.054321    1.282836
+     11          1           0       -1.683511   -0.391282    1.216404
+     12          1           0       -3.531773   -0.898788   -0.119318
+     13          1           0       -0.876510    1.010706   -1.361974
+     14          1           0       -0.009892    1.087423    0.161804
+     15          1           0        1.028811   -0.465428   -1.442890
+     16          1           0       -0.477686   -1.430260   -1.517847
+     17          1           0        0.092835   -2.506323    0.557274
+     18          1           0        2.211062    0.203117    0.704827
+     19          8           0        2.489665    1.112249    0.497209
+     20          8           0        2.681654    1.077109   -0.799910
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518977   0.000000
+     3  O    2.430896   1.420185   0.000000
+     4  C    2.515944   1.519200   2.363499   0.000000
+     5  C    3.911100   2.569032   2.872306   1.540820   0.000000
+     6  C    4.512366   3.116658   3.567714   2.529515   1.495021
+     7  O    5.088004   3.878124   4.600908   3.171368   2.391213
+     8  H    1.092517   2.163379   2.713871   3.467249   4.723857
+     9  H    1.091536   2.155480   2.695002   2.769300   4.201276
+    10  H    1.091260   2.162268   3.372929   2.774110   4.227470
+    11  H    2.139204   1.100934   2.064129   2.143522   2.822524
+    12  H    2.572986   1.953483   0.957872   3.208297   3.764251
+    13  H    2.730725   2.138946   2.632446   1.092094   2.138345
+    14  H    2.738965   2.142816   3.311253   1.090489   2.168495
+    15  H    4.655292   3.479059   3.840430   2.141475   1.091317
+    16  H    4.196614   2.798138   2.527616   2.162214   1.089268
+    17  H    4.802459   3.343095   3.501715   3.207366   2.234467
+    18  H    5.044670   4.161712   5.149784   3.087572   2.790950
+    19  O    5.187212   4.528854   5.597978   3.338027   3.324501
+    20  O    5.569103   4.827990   5.674435   3.397294   3.153191
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.206995   0.000000
+     8  H    5.164823   5.778400   0.000000
+     9  H    5.094953   5.732392   1.771405   0.000000
+    10  H    4.676776   4.999231   1.764263   1.773935   0.000000
+    11  H    2.796704   3.429373   2.478514   3.052404   2.478880
+    12  H    4.263323   5.267811   2.446632   2.920605   3.575795
+    13  H    3.440077   4.100151   3.735681   2.532315   3.088588
+    14  H    2.770818   2.985476   3.740035   3.096266   2.547293
+    15  H    2.090428   2.589740   5.573353   4.807423   4.843662
+    16  H    2.125505   3.229762   4.883936   4.380079   4.750014
+    17  H    1.103855   1.981652   5.254090   5.466099   5.104846
+    18  H    2.420599   1.629460   5.917391   5.537197   4.711540
+    19  O    3.282187   2.599222   6.135329   5.557726   4.734181
+    20  O    3.524820   3.129313   6.594363   5.726155   5.290855
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.336191   0.000000
+    13  H    3.043822   3.498683   0.000000
+    14  H    2.469767   4.053112   1.754654   0.000000
+    15  H    3.799215   4.768498   2.411590   2.462781   0.000000
+    16  H    3.163798   3.400852   2.478240   3.062481   1.790546
+    17  H    2.839587   4.022404   4.122213   3.616899   3.006985
+    18  H    3.972747   5.905385   3.802232   2.451430   2.541133
+    19  O    4.493689   6.378251   3.846818   2.522082   2.896056
+    20  O    5.027560   6.555460   3.602896   2.858220   2.350475
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.406145   0.000000
+    18  H    3.851957   3.442342   0.000000
+    19  O    4.396587   4.340790   0.973265   0.000000
+    20  O    4.096799   4.624383   1.802652   1.311722   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2673822           0.8065215           0.6998137
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.6616078974 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6492434179 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.001168   -0.002656    0.001106
+         Rot=    1.000000    0.000367   -0.000269    0.000126 Ang=   0.05 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957549900     A.U. after   16 cycles
+            NFock= 16  Conv=0.90D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5022
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15000247D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15055502D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000038378    0.000042016   -0.000231781
+      2        6           0.000081403   -0.000589411    0.000717208
+      3        8           0.000437869   -0.000422426    0.000332869
+      4        6          -0.000101426   -0.002343434   -0.000754693
+      5        6           0.000337552    0.001180559   -0.000998496
+      6        6          -0.009764024   -0.001766172   -0.000147482
+      7        8           0.003841932   -0.001458439    0.004342361
+      8        1          -0.000039106    0.000100012   -0.000005620
+      9        1           0.000041524    0.000021851   -0.000046459
+     10        1           0.000007968    0.000010244    0.000013466
+     11        1          -0.000041530   -0.000048443   -0.000020882
+     12        1          -0.000338659    0.000177436    0.000019476
+     13        1          -0.000509943    0.000251827    0.000148470
+     14        1          -0.000427271   -0.000031648    0.000243364
+     15        1          -0.000329774   -0.000488822   -0.001604220
+     16        1           0.000220218   -0.000011910   -0.000104578
+     17        1          -0.000033646   -0.001218742   -0.001671347
+     18        1          -0.004018150   -0.016339071    0.008128368
+     19        8           0.008515587    0.018681281   -0.008378124
+     20        8           0.002081097    0.004253294    0.000018099
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.018681281 RMS     0.004114043
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0014328529
+ Magnitude of corrector gradient =     0.0082539122
+ Magnitude of analytic gradient =      0.0318672414
+ Magnitude of difference =             0.0352524880
+ Angle between gradients (degrees)=  107.6029
+ Pt  7 Step number  17 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  5.53D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.65D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  4.82D-06
+ Maximum DWI energy   std dev =  0.000372138 at pt    33
+ Maximum DWI gradient std dev =  1.249598549 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686884    1.408962    0.642999
+      2          6           0       -1.929056    0.142218    0.285143
+      3          8           0       -2.699285   -0.707188   -0.552853
+      4          6           0       -0.639387    0.446357   -0.458245
+      5          6           0        0.152352   -0.802387   -0.887070
+      6          6           0        0.653996   -1.601739    0.272001
+      7          8           0        1.615966   -1.293110    0.942498
+      8          1           0       -3.608977    1.171742    1.179114
+      9          1           0       -2.946005    1.963187   -0.261086
+     10          1           0       -2.084234    2.051815    1.286703
+     11          1           0       -1.684635   -0.391739    1.216374
+     12          1           0       -3.559568   -0.842990   -0.150189
+     13          1           0       -0.878555    1.007635   -1.364124
+     14          1           0       -0.009482    1.088626    0.158436
+     15          1           0        1.034052   -0.460093   -1.433833
+     16          1           0       -0.469331   -1.429414   -1.524770
+     17          1           0        0.137922   -2.548171    0.514763
+     18          1           0        2.186140    0.223952    0.742985
+     19          8           0        2.491527    1.116189    0.493667
+     20          8           0        2.682043    1.078372   -0.798606
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518883   0.000000
+     3  O    2.430701   1.420204   0.000000
+     4  C    2.516265   1.519333   2.362795   0.000000
+     5  C    3.910555   2.568779   2.872734   1.539514   0.000000
+     6  C    4.512587   3.116684   3.567226   2.529980   1.494676
+     7  O    5.089736   3.880653   4.604430   3.174026   2.393803
+     8  H    1.092679   2.163616   2.712494   3.467793   4.723759
+     9  H    1.091641   2.156033   2.697574   2.767694   4.200009
+    10  H    1.091239   2.161889   3.372589   2.776674   4.227775
+    11  H    2.139108   1.100928   2.063779   2.144597   2.822699
+    12  H    2.542049   1.954154   0.959513   3.206988   3.784573
+    13  H    2.731238   2.138359   2.629418   1.092177   2.136944
+    14  H    2.739690   2.143947   3.311484   1.090681   2.166842
+    15  H    4.653167   3.478170   3.843825   2.138650   1.092479
+    16  H    4.203944   2.806530   2.537504   2.164466   1.089180
+    17  H    4.863628   3.400488   3.546656   3.243170   2.238996
+    18  H    5.016036   4.141394   5.139417   3.078315   2.801204
+    19  O    5.188830   4.531408   5.600397   3.340274   3.325524
+    20  O    5.568922   4.828368   5.675149   3.398115   3.153477
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.212520   0.000000
+     8  H    5.166042   5.781999   0.000000
+     9  H    5.094398   5.732684   1.772030   0.000000
+    10  H    4.677177   4.999848   1.763787   1.773741   0.000000
+    11  H    2.797345   3.432411   2.479708   3.052805   2.477010
+    12  H    4.302100   5.308740   2.414256   2.874611   3.552628
+    13  H    3.440124   4.103239   3.734995   2.530636   3.093680
+    14  H    2.773295   2.988226   3.742333   3.092576   2.550552
+    15  H    2.087503   2.584470   5.572081   4.805047   4.840941
+    16  H    2.126016   3.233334   4.892277   4.386406   4.757231
+    17  H    1.104988   1.985636   5.321501   5.519502   5.166599
+    18  H    2.429494   1.632905   5.888285   5.511081   4.676838
+    19  O    3.288281   2.602456   6.139142   5.554621   4.737287
+    20  O    3.527346   3.129199   6.595227   5.722478   5.292778
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.363576   0.000000
+    13  H    3.044171   3.476533   0.000000
+    14  H    2.473227   4.053332   1.755003   0.000000
+    15  H    3.797305   4.784945   2.411877   2.454142   0.000000
+    16  H    3.172948   3.432627   2.476384   3.063522   1.791093
+    17  H    2.909325   4.125680   4.148156   3.657183   2.993350
+    18  H    3.947921   5.911792   3.800846   2.431073   2.556122
+    19  O    4.498498   6.392862   3.849757   2.523526   2.885161
+    20  O    5.028842   6.562757   3.605922   2.856631   2.342277
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.404177   0.000000
+    18  H    3.863659   3.454265   0.000000
+    19  O    4.395551   4.355162   0.975452   0.000000
+    20  O    4.092367   4.620531   1.830971   1.306789   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2645318           0.8059776           0.6991283
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.4571157199 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.4447780340 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000951    0.002273   -0.001050
+         Rot=    1.000000   -0.000446    0.000284   -0.000082 Ang=  -0.06 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957682711     A.U. after   16 cycles
+            NFock= 16  Conv=0.88D-08     -V/T= 2.0042
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15132027D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15180302D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000208633    0.000107498   -0.000222694
+      2        6          -0.000033838   -0.000514639    0.000325332
+      3        8          -0.001197798   -0.000412245    0.000907732
+      4        6          -0.000441204   -0.001776453   -0.001110022
+      5        6          -0.000492407    0.002413839    0.000481820
+      6        6           0.001997146   -0.004841623   -0.000352011
+      7        8          -0.005092991   -0.001945211    0.002106444
+      8        1          -0.000014226    0.000086165    0.000000812
+      9        1           0.000028947   -0.000012174   -0.000027918
+     10        1          -0.000009948    0.000023732   -0.000015296
+     11        1           0.000011477   -0.000081213    0.000054761
+     12        1           0.001300990    0.000076759   -0.000542569
+     13        1          -0.000529074    0.000428935    0.000317270
+     14        1          -0.000582925   -0.000077602    0.000257041
+     15        1          -0.000636119   -0.000941968   -0.001190139
+     16        1          -0.000017609   -0.000001598    0.000184984
+     17        1          -0.001243020    0.001204057   -0.000395037
+     18        1          -0.002913691   -0.016458895    0.001796240
+     19        8           0.008578646    0.022542636   -0.001647936
+     20        8           0.001079011    0.000180000   -0.000928813
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.022542636 RMS     0.003986509
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0012896916
+ Magnitude of corrector gradient =     0.0068259821
+ Magnitude of analytic gradient =      0.0308793686
+ Magnitude of difference =             0.0292304333
+ Angle between gradients (degrees)=   69.7789
+ Pt  7 Step number  18 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  3.84D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  2.53D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  3.75D-06
+ Maximum DWI energy   std dev =  0.000368169 at pt    31
+ Maximum DWI gradient std dev =  1.236377637 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.687005    1.408881    0.643121
+      2          6           0       -1.928980    0.142175    0.285155
+      3          8           0       -2.699141   -0.707585   -0.552542
+      4          6           0       -0.639095    0.446963   -0.457363
+      5          6           0        0.151854   -0.803180   -0.887873
+      6          6           0        0.655036   -1.600378    0.272543
+      7          8           0        1.613695   -1.293955    0.940156
+      8          1           0       -3.606979    1.171466    1.182451
+      9          1           0       -2.950411    1.959810   -0.261615
+     10          1           0       -2.082804    2.054345    1.282791
+     11          1           0       -1.683533   -0.391261    1.216397
+     12          1           0       -3.531575   -0.899223   -0.119104
+     13          1           0       -0.876697    1.010439   -1.362215
+     14          1           0       -0.009774    1.087445    0.161459
+     15          1           0        1.028756   -0.465701   -1.442793
+     16          1           0       -0.477607   -1.430316   -1.517975
+     17          1           0        0.092065   -2.505852    0.558263
+     18          1           0        2.212025    0.204308    0.703587
+     19          8           0        2.490020    1.113089    0.496834
+     20          8           0        2.681730    1.077203   -0.799720
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518976   0.000000
+     3  O    2.430882   1.420204   0.000000
+     4  C    2.516006   1.519221   2.363436   0.000000
+     5  C    3.911046   2.568961   2.872239   1.540714   0.000000
+     6  C    4.512450   3.116695   3.567681   2.529653   1.495086
+     7  O    5.088180   3.878407   4.601362   3.171581   2.391554
+     8  H    1.092518   2.163391   2.713891   3.467309   4.723801
+     9  H    1.091536   2.155476   2.694953   2.769332   4.201234
+    10  H    1.091265   2.162252   3.372918   2.774186   4.227403
+    11  H    2.139186   1.100913   2.064138   2.143582   2.822459
+    12  H    2.573253   1.953522   0.957883   3.208282   3.764025
+    13  H    2.730813   2.138928   2.632200   1.092115   2.138255
+    14  H    2.739139   2.142938   3.311287   1.090506   2.168337
+    15  H    4.655317   3.479012   3.840348   2.141438   1.091231
+    16  H    4.196762   2.798301   2.527768   2.162210   1.089288
+    17  H    4.801621   3.342343   3.501212   3.207057   2.234721
+    18  H    5.045309   4.162555   5.150627   3.087973   2.791430
+    19  O    5.187532   4.529353   5.598521   3.338500   3.325135
+    20  O    5.569122   4.828030   5.674534   3.397395   3.153392
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.207737   0.000000
+     8  H    5.164864   5.778620   0.000000
+     9  H    5.095048   5.732565   1.771411   0.000000
+    10  H    4.676897   4.999262   1.764271   1.773941   0.000000
+    11  H    2.796735   3.429705   2.478490   3.052382   2.478874
+    12  H    4.262947   5.267983   2.446934   2.920981   3.576005
+    13  H    3.440204   4.100390   3.735732   2.532373   3.088769
+    14  H    2.771047   2.985479   3.740236   3.096346   2.547496
+    15  H    2.090343   2.589711   5.573353   4.807500   4.843682
+    16  H    2.125502   3.230255   4.884111   4.380200   4.750138
+    17  H    1.103837   1.982396   5.253113   5.465436   5.103958
+    18  H    2.422169   1.630570   5.918236   5.537522   4.712077
+    19  O    3.283348   2.599681   6.135706   5.557920   4.734387
+    20  O    3.525149   3.128939   6.594373   5.726218   5.290789
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.335990   0.000000
+    13  H    3.043844   3.498645   0.000000
+    14  H    2.470007   4.053226   1.754727   0.000000
+    15  H    3.799124   4.768303   2.411687   2.462607   0.000000
+    16  H    3.163966   3.400826   2.478068   3.062431   1.790326
+    17  H    2.838552   4.021299   4.122019   3.616574   3.007297
+    18  H    3.974047   5.906229   3.802314   2.451576   2.540863
+    19  O    4.494372   6.378745   3.847257   2.522322   2.896554
+    20  O    5.027587   6.555506   3.603229   2.858001   2.350833
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.406672   0.000000
+    18  H    3.852461   3.443881   0.000000
+    19  O    4.397178   4.341739   0.972579   0.000000
+    20  O    4.096944   4.624799   1.800694   1.311142   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2672093           0.8064463           0.6997316
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.6470693239 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.6347046681 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=    -0.000800   -0.002010    0.001011
+         Rot=    1.000000    0.000506   -0.000297    0.000051 Ang=   0.07 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957529530     A.U. after   16 cycles
+            NFock= 16  Conv=0.95D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.14997122D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15052574D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9825 LenP2D=   22648.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000047414    0.000048086   -0.000229729
+      2        6           0.000073505   -0.000586840    0.000698455
+      3        8           0.000429092   -0.000430354    0.000345194
+      4        6          -0.000111262   -0.002315903   -0.000723891
+      5        6           0.000366257    0.000996453   -0.001015445
+      6        6          -0.008934663   -0.001229734    0.000551838
+      7        8           0.002916941   -0.001835892    0.003643200
+      8        1          -0.000036831    0.000098566   -0.000007846
+      9        1           0.000040945    0.000021801   -0.000045537
+     10        1           0.000005099    0.000009986    0.000012081
+     11        1          -0.000033220   -0.000052242   -0.000015889
+     12        1          -0.000328844    0.000183809    0.000014447
+     13        1          -0.000500355    0.000247124    0.000160008
+     14        1          -0.000447745   -0.000031497    0.000243712
+     15        1          -0.000287120   -0.000453717   -0.001626812
+     16        1           0.000206374   -0.000000081   -0.000098048
+     17        1           0.000046212   -0.001226176   -0.001692096
+     18        1          -0.004223392   -0.016845685    0.008513039
+     19        8           0.008545447    0.018995790   -0.008050835
+     20        8           0.002226147    0.004406505   -0.000675846
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.018995790 RMS     0.004127046
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0014651805
+ Magnitude of corrector gradient =     0.0080700664
+ Magnitude of analytic gradient =      0.0319679584
+ Magnitude of difference =             0.0346136135
+ Angle between gradients (degrees)=  102.4261
+ Pt  7 Step number  19 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  5.48D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  3.62D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  4.72D-06
+ Maximum DWI energy   std dev =  0.000365476 at pt    32
+ Maximum DWI gradient std dev =  1.247388766 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+                          Input orientation:                          
+ ---------------------------------------------------------------------
+ Center     Atomic      Atomic             Coordinates (Angstroms)
+ Number     Number       Type             X           Y           Z
+ ---------------------------------------------------------------------
+      1          6           0       -2.686884    1.408955    0.643005
+      2          6           0       -1.929063    0.142211    0.285137
+      3          8           0       -2.699271   -0.707215   -0.552836
+      4          6           0       -0.639355    0.446417   -0.458126
+      5          6           0        0.152410   -0.802370   -0.887103
+      6          6           0        0.654150   -1.601496    0.272049
+      7          8           0        1.615608   -1.293422    0.942331
+      8          1           0       -3.608972    1.171723    1.179115
+      9          1           0       -2.946021    1.963169   -0.261082
+     10          1           0       -2.084243    2.051821    1.286698
+     11          1           0       -1.684618   -0.391746    1.216379
+     12          1           0       -3.559474   -0.843156   -0.150080
+     13          1           0       -0.878342    1.007901   -1.363902
+     14          1           0       -0.009561    1.088570    0.158770
+     15          1           0        1.034047   -0.459898   -1.433962
+     16          1           0       -0.469478   -1.429396   -1.524578
+     17          1           0        0.138176   -2.548157    0.514378
+     18          1           0        2.185600    0.223273    0.743694
+     19          8           0        2.491217    1.115454    0.493980
+     20          8           0        2.681981    1.078300   -0.798767
+ ---------------------------------------------------------------------
+                    Distance matrix (angstroms):
+                    1          2          3          4          5
+     1  C    0.000000
+     2  C    1.518882   0.000000
+     3  O    2.430713   1.420191   0.000000
+     4  C    2.516216   1.519318   2.362856   0.000000
+     5  C    3.910598   2.568834   2.872781   1.539604   0.000000
+     6  C    4.512530   3.116677   3.567296   2.529873   1.494650
+     7  O    5.089585   3.880418   4.604057   3.173827   2.393515
+     8  H    1.092676   2.163604   2.712493   3.467744   4.723800
+     9  H    1.091640   2.156025   2.697583   2.767683   4.200045
+    10  H    1.091235   2.161900   3.372599   2.776587   4.227816
+    11  H    2.139117   1.100943   2.063774   2.144542   2.822751
+    12  H    2.542126   1.954125   0.959502   3.207022   3.784567
+    13  H    2.731180   2.138402   2.629682   1.092158   2.137023
+    14  H    2.739560   2.143841   3.311460   1.090671   2.166965
+    15  H    4.653142   3.478198   3.843853   2.138676   1.092532
+    16  H    4.203753   2.806315   2.537282   2.164451   1.089165
+    17  H    4.863769   3.400605   3.546705   3.243114   2.238778
+    18  H    5.015683   4.140930   5.138945   3.078073   2.800947
+    19  O    5.188552   4.530970   5.599920   3.339850   3.324974
+    20  O    5.568909   4.828337   5.675069   3.398027   3.153324
+                    6          7          8          9         10
+     6  C    0.000000
+     7  O    1.211854   0.000000
+     8  H    5.166016   5.781803   0.000000
+     9  H    5.094339   5.732543   1.772021   0.000000
+    10  H    4.677075   4.999814   1.763787   1.773737   0.000000
+    11  H    2.797336   3.432145   2.479710   3.052811   2.477027
+    12  H    4.302081   5.308256   2.414321   2.874736   3.552679
+    13  H    3.440032   4.102997   3.734985   2.530621   3.093484
+    14  H    2.773049   2.988148   3.742162   3.092571   2.550368
+    15  H    2.087593   2.584521   5.572071   4.804980   4.840914
+    16  H    2.126035   3.232911   4.892054   4.386249   4.757058
+    17  H    1.105043   1.985021   5.321701   5.519571   5.166761
+    18  H    2.428492   1.632395   5.887802   5.510929   4.676536
+    19  O    3.287230   2.601998   6.138801   5.554484   4.737089
+    20  O    3.527045   3.129479   6.595213   5.722456   5.292806
+                   11         12         13         14         15
+    11  H    0.000000
+    12  H    2.363486   0.000000
+    13  H    3.044166   3.476816   0.000000
+    14  H    2.472992   4.053251   1.754941   0.000000
+    15  H    3.797380   4.784943   2.411757   2.454315   0.000000
+    16  H    3.172716   3.432346   2.476570   3.063549   1.791292
+    17  H    2.909552   4.125670   4.148107   3.657057   2.993233
+    18  H    3.947185   5.911174   3.800703   2.430968   2.556362
+    19  O    4.497900   6.392326   3.849314   2.523287   2.884795
+    20  O    5.028821   6.562663   3.605584   2.856813   2.342053
+                   16         17         18         19         20
+    16  H    0.000000
+    17  H    2.403791   0.000000
+    18  H    3.863394   3.453311   0.000000
+    19  O    4.395060   4.354223   0.975574   0.000000
+    20  O    4.092314   4.620225   1.832117   1.307275   0.000000
+ Symmetry turned off by external request.
+ Stoichiometry    C5H11O4(2)
+ Framework group  C1[X(C5H11O4)]
+ Deg. of freedom    54
+ Full point group                 C1      NOp   1
+ Rotational constants (GHZ):           2.2647230           0.8060412           0.6992010
+ Standard basis: def2TZVP (5D, 7F)
+   345 basis functions,   547 primitive gaussians,   390 cartesian basis functions
+    37 alpha electrons       36 beta electrons
+       nuclear repulsion energy       475.4725861531 Hartrees.
+ NAtoms=   20 NActive=   20 NUniq=   20 SFac= 1.00D+00 NAtFMM=   60 NAOKFM=F Big=F
+ Integral buffers will be    131072 words long.
+ Raffenetti 2 integral format.
+ Two-electron integral symmetry is turned off.
+ Nuclear repulsion after empirical dispersion term =      475.4602482929 Hartrees.
+ One-electron integrals computed using PRISM.
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 6 Len=  172
+ NBasis=   345 RedAO= T EigKep=  1.51D-04  NBF=   345
+ NBsUse=   345 1.00D-06 EigRej= -1.00D+00 NBFU=   345
+ Initial guess from the checkpoint file:  "/tmp/24487558/Gau-315327.chk"
+ B after Tr=     0.000682    0.001803   -0.000960
+         Rot=    1.000000   -0.000545    0.000304   -0.000028 Ang=  -0.07 deg.
+ Initial guess <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ ExpMin= 9.52D-02 ExpMax= 2.70D+04 ExpMxC= 9.22D+02 IAcc=3 IRadAn=         5 AccDes= 0.00D+00
+ Harris functional with IExCor= 4639 and IRadAn=       5 diagonalized for initial guess.
+ HarFok:  IExCor= 4639 AccDes= 0.00D+00 IRadAn=         5 IDoV= 1 UseB2=F ITyADJ=14
+ ICtDFT=  3500011 ScaDFX=  1.000000  1.000000  1.000000  1.000000
+ FoFCou: FMM=F IPFlag=           0 FMFlag=      100000 FMFlg1=           0
+         NFxFlg=           0 DoJE=T BraDBF=F KetDBF=T FulRan=T
+         wScrn=  0.000000 ICntrl=       500 IOpCl=  0 I1Cent=   200000004 NGrid=           0
+         NMat0=    1 NMatS0=      1 NMatT0=    0 NMatD0=    1 NMtDS0=    0 NMtDT0=    0
+ Symmetry not used in FoFCou.
+ Requested convergence on RMS density matrix=1.00D-08 within  32 cycles.
+ Requested convergence on MAX density matrix=1.00D-06.
+ Requested convergence on             energy=1.00D-06.
+ No special actions if energy rises.
+ Integral accuracy reduced to 1.0D-05 until final iterations.
+ Initial convergence to 1.0D-05 achieved.  Increase integral accuracy.
+ SCF Done:  E(UwB97XD) =  -497.957672838     A.U. after   16 cycles
+            NFock= 16  Conv=0.84D-08     -V/T= 2.0041
+ <Sx>= 0.0000 <Sy>= 0.0000 <Sz>= 0.5000 <S**2>= 0.7543 S= 0.5021
+ <L.S>=  0.00000000000    
+ Annihilation of the first spin contaminant:
+ S**2 before annihilation     0.7543,   after     0.7500
+ QCSCF skips out because SCF is already converged.
+ DoSCS=F DFT=T ScalE2(SS,OS)=  1.000000  1.000000
+ Range of M.O.s used for correlation:     1   345
+ NBasis=   345 NAE=    37 NBE=    36 NFC=     0 NFV=     0
+ NROrb=    345 NOA=    37 NOB=    36 NVA=   308 NVB=   309
+
+ **** Warning!!: The largest alpha MO coefficient is  0.15133457D+02
+
+
+ **** Warning!!: The largest beta MO coefficient is  0.15181612D+02
+
+ Symmetrizing basis deriv contribution to polar:
+ IMax=3 JMax=2 DiffMx= 0.00D+00
+   1 Symmetry operations used in ECPInt.
+ ECPInt:  NShTT=   10296 NPrTT=   30612 LenC2=    9823 LenP2D=   22635.
+ LDataN:  DoStor=T MaxTD1= 7 Len=  274
+ Calling FoFJK, ICntrl=      2127 FMM=F ISym2X=0 I1Cent= 0 IOpClX= 1 NMat=1 NMatS=1 NMatT=0.
+ -------------------------------------------------------------------
+ Center     Atomic                   Forces (Hartrees/Bohr)
+ Number     Number              X              Y              Z
+ -------------------------------------------------------------------
+      1        6           0.000199848    0.000103456   -0.000225223
+      2        6          -0.000026281   -0.000517605    0.000341435
+      3        8          -0.001187177   -0.000407583    0.000898964
+      4        6          -0.000428017   -0.001804157   -0.001127011
+      5        6          -0.000507377    0.002548909    0.000493645
+      6        6           0.001229681   -0.005267644   -0.000903585
+      7        8          -0.004290683   -0.001638297    0.002685265
+      8        1          -0.000016316    0.000087535    0.000002732
+      9        1           0.000029131   -0.000011481   -0.000028618
+     10        1          -0.000007941    0.000023896   -0.000013705
+     11        1           0.000005513   -0.000078485    0.000050088
+     12        1           0.001289799    0.000075215   -0.000539559
+     13        1          -0.000539830    0.000432061    0.000306328
+     14        1          -0.000569031   -0.000077040    0.000255558
+     15        1          -0.000667107   -0.000969451   -0.001181668
+     16        1          -0.000001745   -0.000009517    0.000175429
+     17        1          -0.001286484    0.001205487   -0.000396272
+     18        1          -0.002854377   -0.016395440    0.001597699
+     19        8           0.008660532    0.022615067   -0.002012151
+     20        8           0.000967864    0.000085074   -0.000379351
+ -------------------------------------------------------------------
+ Cartesian Forces:  Max     0.022615067 RMS     0.003985547
+ IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC-IRC
+ Error in corrector energy =          -0.0013099995
+ Magnitude of corrector gradient =     0.0068851851
+ Magnitude of analytic gradient =      0.0308719145
+ Magnitude of difference =             0.0298709507
+ Angle between gradients (degrees)=   75.2540
+ Pt  7 Step number  20 out of a maximum of  20
+ Modified Bulirsch-Stoer Extrapolation Cycles:
+    EPS =    0.000010000000000
+      PEZero:  N= 2 I= 1 D=  1.25D-03 Err=  3.91D-04
+      PEZero:  N= 3 I= 2 D=  1.25D-03 Err=  2.58D-04
+      PEZero:  N= 3 I= 1 D=  2.50D-03 Err=  3.77D-06
+ Maximum DWI energy   std dev =  0.000367214 at pt    31
+ Maximum DWI gradient std dev =  1.234267499 at pt    48
+ CORRECTOR INTEGRATION CONVERGENCE:
+   Recorrection delta-x convergence threshold:    0.010000
+   Delta-x Convergence NOT Met
+ Maximum number of corrector steps exceded.
+ Error termination via Lnk1e in /home/gridsan/nmorgan/RMG_shared/Software/gaussian_16_c02/g16/l123.exe at Thu Dec 14 13:10:51 2023.
+ Job cpu time:       0 days 13 hours 20 minutes 22.1 seconds.
+ Elapsed time:       0 days  1 hours 42 minutes 32.6 seconds.
+ File lengths (MBytes):  RWF=    384 Int=      0 D2E=      0 Chk=     14 Scr=      1

--- a/test/external/logparser/test_irc.py
+++ b/test/external/logparser/test_irc.py
@@ -1,0 +1,12 @@
+from rdmc.external.logparser import GaussianLog
+from rdmc.utils import repo_dir
+
+data_path = repo_dir / 'test' / 'data'
+
+def test_fail_irc_with_correction_steps():
+    log_file = data_path / 'gaussian_irc_with_correction_failed.log'
+    log = GaussianLog(log_file)
+    assert not log.success
+    # See if energy values can be correctedly loaded
+    assert log.get_scf_energies(converged=True).shape[0] == 7
+    assert log.get_scf_energies(converged=False).shape[0] == 35


### PR DESCRIPTION
Fix a bug related to parsing IRC jobs.

An example of the job is attached under /test/data
The job uses the G16's default IRC algorithm, which involves a correction step. The job failed after a few steps, and the backend cclib parsed one more energy value than the geometries, causing IndexError in the Logparse. This PR aims to solve the issue. 