### PR TITLE
Fix doc: fix reaction/rdkitmol usage on the index page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,8 +37,8 @@ To start with, simply try:
 .. code-block:: python
 
     from rdmc import RDKitMol, Reaction
-    mol = RDKitMol('CCO')
-    rxn = Reaction('CCO>>CC(=O)O')
+    mol = RDKitMol.FromSmiles('CCO')
+    rxn = Reaction.from_reaction_smiles('CCO>>CC(=O)O')
 
 And see what the ``mol`` and ``rxn`` are capable of! The full lists of APIs of :obj:`RDKitMol <rdmc.mol.RDKitMol>` and :obj:`Reaction <rdmc.reaction.Reaction>` are provided in this documentation.
 

--- a/test/external/logparser/test_irc.py
+++ b/test/external/logparser/test_irc.py
@@ -3,10 +3,11 @@ from rdmc.utils import repo_dir
 
 data_path = repo_dir / 'test' / 'data'
 
+
 def test_fail_irc_with_correction_steps():
     log_file = data_path / 'gaussian_irc_with_correction_failed.log'
     log = GaussianLog(log_file)
     assert not log.success
-    # See if energy values can be correctedly loaded
+    # See if energy values can be correctly loaded
     assert log.get_scf_energies(converged=True).shape[0] == 7
     assert log.get_scf_energies(converged=False).shape[0] == 35


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please try to provide as much detail as possible to help the reviewer understand your work.
You can also add the appropriate labels to describe the topic of the pull request and the type of changes you're making.
-->

This PR fixes the problem identified in #82.

Review suggestion: try the new example
``` 
from rdmc import RDKitMol, Reaction
mol = RDKitMol.FromSmiles('CCO')
rxn = Reaction.from_reaction_smiles('CCO>>CC(=O)O')
```

<!--
Checklist before submission:
 - Have you added appropriate unit tests?
 - Have you checked that all unit tests pass?
 - Is your code commented and understandable?
 - Have you updated related documentation?
 - Are the commits logically organized and informative?
 - Is your branch up to date with main?
-->